### PR TITLE
[15] Use category internal server error as default

### DIFF
--- a/src/test/java/com/sixt/service/framework/rpc/RpcCallExceptionTest.java
+++ b/src/test/java/com/sixt/service/framework/rpc/RpcCallExceptionTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
@@ -34,6 +34,21 @@ public class RpcCallExceptionTest {
     public void testJsonToString() {
         RpcCallException ex = new RpcCallException(RpcCallException.Category.InternalServerError, "feckoff");
         System.out.println(ex.toString());
+    }
+
+    @Test
+    public void testFromJson_ErrorWithoutCategory() {
+        String error = "{\"id\":\"com.sixt.service.foobar\",\"code\":500,\"message\":\"error message\",\"status\":\"Internal Server Error\"}";
+        RpcCallException ex = RpcCallException.fromJson(error);
+        assertThat(ex.getCategory()).isEqualTo(RpcCallException.Category.InternalServerError);
+    }
+
+    @Test
+    public void testFromJson_ErrorWithDetailInsteadOfMessage() {
+        String error = "{\"id\":\"com.sixt.service.foobar\",\"code\":500,\"detail\":\"error message\",\"status\":\"Internal Server Error\"}";
+        RpcCallException ex = RpcCallException.fromJson(error);
+        assertThat(ex.getCategory()).isEqualTo(RpcCallException.Category.InternalServerError);
+        assertThat(ex.getMessage()).isEqualTo("error message");
     }
 
 }


### PR DESCRIPTION
- use internal server error if no `category` or `code` can be found
- use empty message if response does not contain a `message` or `detail`