### PR TITLE
add opentracing support for RPC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,8 @@ ext.versions = [
         'kafka'   : '0.10.1.0',
         'guava'   : '20.0',
         'logback' : '1.1.8',
-        'slf4j'   : '1.7.22'
+        'slf4j'   : '1.7.22',
+        'tracing' : '0.20.10'
 ]
 
 dependencies { //achtung: order does matter!
@@ -132,6 +133,10 @@ dependencies { //achtung: order does matter!
 
     //metrics
     compile 'io.dropwizard.metrics:metrics-core:3.1.2'
+
+    //tracing
+    compile "io.opentracing:opentracing-api:$versions.tracing"
+    compile "io.opentracing:opentracing-noop:$versions.tracing"
 
     //Classpath scanner
     compile 'io.github.lukehutch:fast-classpath-scanner:2.0.10'

--- a/src/main/java/com/sixt/service/framework/AbstractService.java
+++ b/src/main/java/com/sixt/service/framework/AbstractService.java
@@ -61,6 +61,7 @@ public abstract class AbstractService {
     private List<String> serviceRegistryPlugins;
     private List<String> configurationPlugins;
     private List<String> metricsReporterPlugins;
+    private List<String> tracingPlugins;
 
     public void registerMethodHandlers(List<String> rpcHandlers) {
 
@@ -112,6 +113,8 @@ public abstract class AbstractService {
             registryModule.setServiceRegistryPlugins(serviceRegistryPlugins);
             MetricsReporterModule metricsModule = new MetricsReporterModule();
             metricsModule.setPlugins(metricsReporterPlugins);
+            TracingModule tracingModule = new TracingModule(serviceProperties);
+            tracingModule.setPlugins(tracingPlugins);
 
             List<Module> modules = getGuiceModules();
             if (modules == null) {
@@ -123,6 +126,7 @@ public abstract class AbstractService {
             modules.add(0, new OrangeServletModule());
             modules.add(0, registryModule);
             modules.add(0, metricsModule);
+            modules.add(0, tracingModule);
             modules.add(0, mainModule);
             //^^^ the order of the modules is specifically controlled here
             injector = Guice.createInjector((Module[]) modules.toArray(new Module[0]));
@@ -304,5 +308,9 @@ public abstract class AbstractService {
         if (provider != null) {
             provider.initialize();
         }
+    }
+
+    public void setTracingPlugins(List<String> tracingPlugins) {
+        this.tracingPlugins = tracingPlugins;
     }
 }

--- a/src/main/java/com/sixt/service/framework/JettyServiceBase.java
+++ b/src/main/java/com/sixt/service/framework/JettyServiceBase.java
@@ -39,6 +39,7 @@ public class JettyServiceBase {
             List<String> serviceRegistryPlugins = new ArrayList<>();
             List<String> configPlugins = new ArrayList<>();
             List<String> metricsReportingPlugins = new ArrayList<>();
+            List<String> tracingPlugins = new ArrayList<>();
 
             new FastClasspathScanner()
                     .matchClassesWithAnnotation(OrangeMicroservice.class, matchingClass ->
@@ -53,6 +54,8 @@ public class JettyServiceBase {
                             configPlugins.add(matchingClass.getCanonicalName()))
                     .matchClassesWithAnnotation(MetricsReporterPlugin.class, matchingClass ->
                             metricsReportingPlugins.add(matchingClass.getCanonicalName()))
+                    .matchClassesWithAnnotation(TracingPlugin.class, matchingClass ->
+                            tracingPlugins.add(matchingClass.getCanonicalName()))
                     .scan();
 
             if (serviceEntries.isEmpty()) {
@@ -75,6 +78,7 @@ public class JettyServiceBase {
             service.setConfigurationPlugins(configPlugins);
             service.setServiceRegistryPlugins(serviceRegistryPlugins);
             service.setMetricsReporterPlugins(metricsReportingPlugins);
+            service.setTracingPlugins(tracingPlugins);
 
             service.initializeConfigurationManager();
 

--- a/src/main/java/com/sixt/service/framework/OrangeContext.java
+++ b/src/main/java/com/sixt/service/framework/OrangeContext.java
@@ -12,6 +12,8 @@
 
 package com.sixt.service.framework;
 
+import io.opentracing.SpanContext;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -29,6 +31,7 @@ public class OrangeContext {
 
     private String correlationId;
     private Map<String, String> properties = new HashMap<>();
+    private SpanContext tracingContext;
 
     public OrangeContext() {
         this(null, null);
@@ -81,6 +84,14 @@ public class OrangeContext {
 
     public String getProperty(String key) {
         return properties.get(key.toLowerCase());
+    }
+
+    public SpanContext getTracingContext() {
+        return tracingContext;
+    }
+
+    public void setTracingContext(SpanContext tracingContext) {
+        this.tracingContext = tracingContext;
     }
 
     //TODO: getIntProperty, getLongProperty, etc.

--- a/src/main/java/com/sixt/service/framework/annotation/TracingPlugin.java
+++ b/src/main/java/com/sixt/service/framework/annotation/TracingPlugin.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.sixt.service.framework.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This is a marker annotation to denote this is the Plugin for the tracing
+ * implementation with the given name.  The class using this annotation must also
+ * implement com.sixt.service.framework.tracing.TracingProvider.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TracingPlugin {
+    String name();
+}

--- a/src/main/java/com/sixt/service/framework/injection/TracingModule.java
+++ b/src/main/java/com/sixt/service/framework/injection/TracingModule.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.sixt.service.framework.injection;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.sixt.service.framework.ServiceProperties;
+import com.sixt.service.framework.annotation.TracingPlugin;
+import com.sixt.service.framework.tracing.TracingProvider;
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+import io.opentracing.Tracer;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class TracingModule extends AbstractModule {
+
+    public static final Logger logger = LoggerFactory.getLogger(TracingModule.class);
+    private final ServiceProperties serviceProperties;
+    private Tracer tracer;
+    private Object plugin;
+    private List<String> plugins;
+
+    public TracingModule(ServiceProperties serviceProperties) {
+        this.serviceProperties = serviceProperties;
+    }
+
+    @Override
+    protected void configure() {
+    }
+
+    @Provides
+    public Tracer getTracer(Injector injector) {
+        if (tracer == null) {
+            Object plugin = getTracingPlugin(injector);
+            if (plugin != null && plugin instanceof TracingProvider) {
+                tracer = ((TracingProvider) plugin).getTracer();
+            }
+        }
+        return tracer;
+    }
+
+    private Object getTracingPlugin(Injector injector) {
+        if (plugin == null) {
+            plugin = findTracingPlugin(injector);
+        }
+        return plugin;
+    }
+
+    private Object findTracingPlugin(Injector injector) {
+        Object retval = null;
+        String pluginName = serviceProperties.getProperty("tracing");
+        if (StringUtils.isBlank(pluginName)) {
+            logger.debug("no tracing plugin set, defaulting to 'noop'");
+            pluginName = "noop";
+        }
+        if (plugins == null) {
+            plugins = new FastClasspathScanner().scan().getNamesOfClassesWithAnnotation(TracingPlugin.class);
+        }
+        boolean found = false;
+        for (String plugin : plugins) {
+            try {
+                Class<? extends TracingPlugin> pluginClass = (Class<? extends TracingPlugin>) Class.forName(plugin);
+                TracingPlugin anno = pluginClass.getAnnotation(TracingPlugin.class);
+                if (anno != null && pluginName.equals(anno.name())) {
+                    retval = injector.getInstance(pluginClass);
+                    found = true;
+                    break;
+                }
+            } catch (ClassNotFoundException e) {
+                logger.error("Tracing plugin not found", e);
+            }
+        }
+        if (! found) {
+            logger.warn("Tracing plugin '{}' was not found in the class path", pluginName);
+        }
+        return retval;
+    }
+
+    public void setPlugins(List<String> plugins) {
+        this.plugins = plugins;
+    }
+
+}

--- a/src/main/java/com/sixt/service/framework/servicetest/service/ServiceMethod.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/service/ServiceMethod.java
@@ -13,6 +13,7 @@
 package com.sixt.service.framework.servicetest.service;
 
 import com.google.protobuf.Message;
+import com.sixt.service.framework.OrangeContext;
 import com.sixt.service.framework.protobuf.ProtobufRpcRequest;
 import com.sixt.service.framework.protobuf.ProtobufUtil;
 import com.sixt.service.framework.rpc.RpcCallException;
@@ -38,7 +39,7 @@ public class ServiceMethod<RESPONSE extends Message> {
         return sendRequest(request, null);
     }
 
-    public RESPONSE sendRequest(Message request, Map<String, String> orangeContext) throws RpcCallException {
+    public RESPONSE sendRequest(Message request, OrangeContext orangeContext) throws RpcCallException {
 
         ProtobufRpcRequest pbRequest = new ProtobufRpcRequest(client.getMethodName(), request);
 

--- a/src/main/java/com/sixt/service/framework/servicetest/service/ServiceUnderTest.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/service/ServiceUnderTest.java
@@ -14,6 +14,7 @@ package com.sixt.service.framework.servicetest.service;
 
 import com.google.gson.JsonObject;
 import com.google.protobuf.Message;
+import com.sixt.service.framework.OrangeContext;
 import com.sixt.service.framework.rpc.LoadBalancer;
 import com.sixt.service.framework.rpc.RpcCallException;
 
@@ -31,7 +32,7 @@ public interface ServiceUnderTest {
      */
     Message sendRequest(String serviceMethod, Message request) throws RpcCallException;
 
-    Message sendRequest(String serviceMethod, Message request, Map<String, String> orangeContext) throws RpcCallException;
+    Message sendRequest(String serviceMethod, Message request, OrangeContext orangeContext) throws RpcCallException;
 
     /**
      * Send an HTTP GET request to the service under test

--- a/src/main/java/com/sixt/service/framework/servicetest/service/ServiceUnderTestImpl.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/service/ServiceUnderTestImpl.java
@@ -16,6 +16,7 @@ import com.google.gson.JsonObject;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.protobuf.Message;
+import com.sixt.service.framework.OrangeContext;
 import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.injection.ServiceRegistryModule;
 import com.sixt.service.framework.registry.ServiceDiscoveryProvider;
@@ -88,7 +89,7 @@ public class ServiceUnderTestImpl implements ServiceUnderTest {
     }
 
     @Override
-    public Message sendRequest(String serviceMethod, Message request, Map<String, String> orangeContext) throws RpcCallException {
+    public Message sendRequest(String serviceMethod, Message request, OrangeContext orangeContext) throws RpcCallException {
         ServiceMethod<Message> method = serviceMethods.get(serviceMethod);
         return method.sendRequest(request, orangeContext);
     }

--- a/src/main/java/com/sixt/service/framework/tracing/NoopTracingProvider.java
+++ b/src/main/java/com/sixt/service/framework/tracing/NoopTracingProvider.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.sixt.service.framework.tracing;
+
+import com.sixt.service.framework.annotation.TracingPlugin;
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.Tracer;
+
+/**
+ * This is the default tracing plugin which just uses the OpenTracing Noop implementation.
+ * That way, tracing can be effectively disabled.
+ */
+@TracingPlugin(name = "noop")
+public class NoopTracingProvider implements TracingProvider {
+
+    @Override
+    public Tracer getTracer() {
+        return NoopTracerFactory.create();
+    }
+
+}

--- a/src/main/java/com/sixt/service/framework/tracing/TracingProvider.java
+++ b/src/main/java/com/sixt/service/framework/tracing/TracingProvider.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.sixt.service.framework.tracing;
+
+import io.opentracing.Tracer;
+
+public interface TracingProvider {
+    Tracer getTracer();
+}

--- a/src/test/java/com/sixt/service/framework/injection/OrangeServletModuleTest.java
+++ b/src/test/java/com/sixt/service/framework/injection/OrangeServletModuleTest.java
@@ -14,6 +14,7 @@ package com.sixt.service.framework.injection;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.jetty.HealthServlet;
 import com.sixt.service.framework.jetty.RpcServlet;
 import org.junit.Test;
@@ -25,7 +26,7 @@ public class OrangeServletModuleTest {
     @Test
     public void testConfigure() {
         OrangeServletModule module = new OrangeServletModule();
-        Injector injector = Guice.createInjector(module);
+        Injector injector = Guice.createInjector(module, new TracingModule(new ServiceProperties()));
         assertThat(injector.getInstance(HealthServlet.class)).isNotNull();
         assertThat(injector.getInstance(RpcServlet.class)).isNotNull();
     }

--- a/src/test/java/com/sixt/service/framework/jetty/JsonHandlerTest.java
+++ b/src/test/java/com/sixt/service/framework/jetty/JsonHandlerTest.java
@@ -65,7 +65,7 @@ public class JsonHandlerTest {
         handlerMetrics = mock(RpcHandlerMetrics.class);
         when(handlerMetrics.getMethodTimer(anyString(), anyString(), anyString())).thenReturn(mock(GoTimer.class));
 
-        servlet = new JsonHandler(handlerDictionary, metricRegistry, handlerMetrics, new ServiceProperties());
+        servlet = new JsonHandler(handlerDictionary, metricRegistry, handlerMetrics, new ServiceProperties(), null);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class JsonHandlerTest {
 
         ServiceProperties props = new ServiceProperties();
         props.addProperty(FeatureFlags.FLAG_EXPOSE_ERRORS_HTTP, "true");
-        servlet = new JsonHandler(handlerDictionary, metricRegistry, handlerMetrics, props);
+        servlet = new JsonHandler(handlerDictionary, metricRegistry, handlerMetrics, props, null);
         servlet.doPost(request, response);
 
         String responseAsString = charArryWriter.toString();
@@ -200,7 +200,7 @@ public class JsonHandlerTest {
         // when
         ServiceProperties props = new ServiceProperties();
         props.addProperty(FeatureFlags.FLAG_EXPOSE_ERRORS_HTTP, "true");
-        servlet = new JsonHandler(handlerDictionary, metricRegistry, handlerMetrics, props);
+        servlet = new JsonHandler(handlerDictionary, metricRegistry, handlerMetrics, props, null);
         servlet.doPost(request, response);
 
         // then

--- a/src/test/java/com/sixt/service/framework/jetty/RpcHandlerTest.java
+++ b/src/test/java/com/sixt/service/framework/jetty/RpcHandlerTest.java
@@ -88,7 +88,7 @@ public class RpcHandlerTest {
         public RpcHandlerTest_RpcHandlerMock(MethodHandlerDictionary handlers,
                                              MetricRegistry registry,
                                              RpcHandlerMetrics handlerMetrics) {
-            super(handlers, registry, handlerMetrics, new ServiceProperties());
+            super(handlers, registry, handlerMetrics, new ServiceProperties(), null);
         }
 
         public Map<String, String> gatherHttpHeaders(HttpServletRequest request) {

--- a/src/test/java/com/sixt/service/framework/rpc/LoadBalancerTest.java
+++ b/src/test/java/com/sixt/service/framework/rpc/LoadBalancerTest.java
@@ -28,7 +28,7 @@ public class LoadBalancerTest {
     public void setup() {
         ServiceProperties properties = new ServiceProperties();
         HttpClient httpClient = mock(HttpClient.class);
-        HttpClientWrapper wrapper = new HttpClientWrapper(properties, httpClient, null);
+        HttpClientWrapper wrapper = new HttpClientWrapper(properties, httpClient, null, null);
         lb = new LoadBalancer(properties, wrapper);
     }
 

--- a/src/test/java/com/sixt/service/framework/rpc/RpcClientIntegrationTest.java
+++ b/src/test/java/com/sixt/service/framework/rpc/RpcClientIntegrationTest.java
@@ -20,6 +20,7 @@ import com.google.inject.Provides;
 import com.sixt.service.framework.FeatureFlags;
 import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.injection.ServiceRegistryModule;
+import com.sixt.service.framework.injection.TracingModule;
 import com.sixt.service.framework.protobuf.FrameworkTest;
 import com.sixt.service.framework.protobuf.RpcEnvelope;
 import org.eclipse.jetty.client.HttpClient;
@@ -71,7 +72,7 @@ public class RpcClientIntegrationTest {
         props.addProperty(ServiceProperties.REGISTRY_SERVER_KEY, "localhost:65432");
         props.addProperty("registry", "consul");
         module.setServiceProperties(props);
-        Injector injector = Guice.createInjector(module, new ServiceRegistryModule(props));
+        Injector injector = Guice.createInjector(module, new ServiceRegistryModule(props), new TracingModule(props));
         httpClient = (MockHttpClient)injector.getInstance(HttpClient.class);
         clientFactory = injector.getInstance(RpcClientFactory.class);
         loadBalancerFactory = injector.getInstance(LoadBalancerFactory.class);


### PR DESCRIPTION
This PR adds support for OpenTracing (opentracing.io) to ja-micro for all RPC calls (incoming and outgoing). The implementation is pluggable and by default the noop-implementation is used.