### PR TITLE
Add tracing module to service impersonator

### DIFF
--- a/sit/src/main/java/com/sixt/service/test_service/ServiceEntryPoint.java
+++ b/sit/src/main/java/com/sixt/service/test_service/ServiceEntryPoint.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
@@ -14,10 +14,7 @@ package com.sixt.service.test_service;
 
 import com.sixt.service.framework.AbstractService;
 import com.sixt.service.framework.annotation.OrangeMicroservice;
-import com.sixt.service.test_service.handler.RandomHandler;
-import com.sixt.service.test_service.handler.RandomHandlerPostHook;
-import com.sixt.service.test_service.handler.RandomHandlerPreHook;
-import com.sixt.service.test_service.handler.SlowRespondingHandler;
+import com.sixt.service.test_service.handler.*;
 
 import java.io.PrintStream;
 
@@ -37,4 +34,9 @@ public class ServiceEntryPoint extends AbstractService {
         //TODO: display required and optional configuration information
     }
 
+    @Override
+    public void bootstrapComplete() throws InterruptedException {
+        injector.getInstance(RandomEventHandler.class);
+        super.bootstrapComplete();
+    }
 }

--- a/sit/src/main/java/com/sixt/service/test_service/handler/RandomEventHandler.java
+++ b/sit/src/main/java/com/sixt/service/test_service/handler/RandomEventHandler.java
@@ -1,0 +1,36 @@
+package com.sixt.service.test_service.handler;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.sixt.service.framework.kafka.EventReceivedCallback;
+import com.sixt.service.framework.kafka.KafkaSubscriber;
+import com.sixt.service.framework.kafka.KafkaSubscriberFactory;
+import com.sixt.service.framework.kafka.KafkaTopicInfo;
+import com.sixt.service.test_service.api.TestServiceOuterClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class RandomEventHandler implements EventReceivedCallback<TestServiceOuterClass.RandomSampleEvent> {
+
+    private static Logger logger = LoggerFactory.getLogger(RandomEventHandler.class);
+
+    private final KafkaSubscriber subscriber;
+
+    @Inject
+    public RandomEventHandler(KafkaSubscriberFactory factory) {
+        this.subscriber = factory.newBuilder("events", this).build();
+    }
+
+    @Override
+    public void eventReceived(TestServiceOuterClass.RandomSampleEvent message, KafkaTopicInfo topicInfo) {
+        try {
+            logger.info("Handling RandomSampleEvent event: {}", message);
+            // do some handling
+        } catch (Exception ex) {
+            logger.warn("Handling RandomSampleEvent event failed", ex);
+        } finally {
+            subscriber.consume(topicInfo);
+        }
+    }
+}

--- a/sit/src/main/proto/TestService.proto
+++ b/sit/src/main/proto/TestService.proto
@@ -6,9 +6,12 @@ option java_multiple_files = false;
 option java_package = "com.sixt.service.test_service.api";
 
 service TestService {
-    rpc GetRandomString(GetRandomStringQuery) returns (RandomStringResponse) {}
-    rpc SlowResponder(GetRandomStringQuery) returns (RandomStringResponse) {}
-    rpc SetHealthCheckStatus(SetHealthCheckStatusCommand) returns (SetHealthCheckStatusResponse) {}
+    rpc GetRandomString (GetRandomStringQuery) returns (RandomStringResponse) {
+    }
+    rpc SlowResponder (GetRandomStringQuery) returns (RandomStringResponse) {
+    }
+    rpc SetHealthCheckStatus (SetHealthCheckStatusCommand) returns (SetHealthCheckStatusResponse) {
+    }
 }
 
 message GetRandomStringQuery {
@@ -26,4 +29,9 @@ message SetHealthCheckStatusCommand {
 
 message SetHealthCheckStatusResponse {
 
+}
+
+message RandomSampleEvent {
+    string id = 1;
+    string message = 2;
 }

--- a/sit/src/serviceTest/java/com/sixt/service/test_service/RandomServiceIntegrationTest.java
+++ b/sit/src/serviceTest/java/com/sixt/service/test_service/RandomServiceIntegrationTest.java
@@ -1,26 +1,30 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
 package com.sixt.service.test_service;
 
+import com.google.gson.JsonObject;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.configuration.ProjectName;
 import com.sixt.service.framework.health.HealthCheck;
+import com.sixt.service.framework.protobuf.ProtobufUtil;
 import com.sixt.service.framework.rpc.LoadBalancer;
 import com.sixt.service.framework.rpc.RpcCallException;
 import com.sixt.service.framework.rpc.ServiceEndpoint;
 import com.sixt.service.framework.servicetest.helper.DockerComposeHelper;
+import com.sixt.service.framework.servicetest.mockservice.ServiceImpersonator;
 import com.sixt.service.framework.servicetest.service.ServiceUnderTest;
 import com.sixt.service.framework.servicetest.service.ServiceUnderTestImpl;
+import com.sixt.service.test_service.api.TestServiceOuterClass;
 import com.sixt.service.test_service.api.TestServiceOuterClass.GetRandomStringQuery;
 import com.sixt.service.test_service.api.TestServiceOuterClass.RandomStringResponse;
 import com.sixt.service.test_service.api.TestServiceOuterClass.SetHealthCheckStatusCommand;
@@ -32,11 +36,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.util.List;
+import java.util.Random;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RandomServiceIntegrationTest {
 
-    private static ServiceUnderTest randomService;
+    private static ServiceUnderTest testService;
 
     @ClassRule
     public static DockerComposeRule docker = DockerComposeRule.builder()
@@ -49,6 +56,8 @@ public class RandomServiceIntegrationTest {
             .projectName(ProjectName.random())
             .build();
 
+    private static ServiceImpersonator serviceImpersonator;
+
     @Rule
     public Timeout globalTimeout = Timeout.seconds(30);
 
@@ -57,13 +66,15 @@ public class RandomServiceIntegrationTest {
         DockerComposeHelper.setKafkaEnvironment(docker);
         DockerComposeHelper.setConsulEnvironment(docker);
 
-        randomService = new ServiceUnderTestImpl("com.sixt.service.test-service", false);
+        serviceImpersonator = new ServiceImpersonator("com.sixt.service.another-service");
+
+        testService = new ServiceUnderTestImpl("com.sixt.service.test-service", "events");
     }
 
     @Test
     public void testGetRandomString() throws Exception {
         GetRandomStringQuery request = GetRandomStringQuery.newBuilder().build();
-        RandomStringResponse response = (RandomStringResponse)randomService.sendRequest(
+        RandomStringResponse response = (RandomStringResponse) testService.sendRequest(
                 "TestService.GetRandomString", request);
 
         String result = response.getRandom();
@@ -73,7 +84,7 @@ public class RandomServiceIntegrationTest {
     @Test
     public void testSlowRespondingService() {
         try {
-            randomService.sendRequest("TestService.SlowResponder",
+            testService.sendRequest("TestService.SlowResponder",
                     GetRandomStringQuery.getDefaultInstance());
         } catch (RpcCallException ex) {
             ex.printStackTrace();
@@ -87,9 +98,9 @@ public class RandomServiceIntegrationTest {
                 .setStatus(HealthCheck.Status.FAIL.toString()).setMessage(failureMessage).build();
         //we have to work around the normal communication channels, as the load-balancer
         //won't let us talk to a failing instance
-        LoadBalancer loadBalancer = randomService.getLoadBalancer();
+        LoadBalancer loadBalancer = testService.getLoadBalancer();
         ServiceEndpoint endpoint = loadBalancer.getHealthyInstance();
-        randomService.sendRequest("TestService.SetHealthCheckStatus", command);
+        testService.sendRequest("TestService.SetHealthCheckStatus", command);
         String url = "http://" + endpoint.getHostAndPort() + "/health";
         HttpClient httpClient = new HttpClient();
         httpClient.start();
@@ -99,4 +110,19 @@ public class RandomServiceIntegrationTest {
                 "{\"name\":\"test_servlet\",\"status\":\"CRITICAL\",\"reason\":\"" + failureMessage + "\"}]}");
     }
 
+    @Test
+    public void testRandomSampleEventHandler() throws Exception {
+        serviceImpersonator.publishEvent("events", TestServiceOuterClass.RandomSampleEvent.newBuilder()
+                .setId("some-id")
+                .setMessage("The message")
+                .build());
+
+        List<JsonObject> receivedEvents = testService.getAllJsonEvents();
+
+        assertThat(receivedEvents.size()).isEqualTo(1);
+        TestServiceOuterClass.RandomSampleEvent event = ProtobufUtil.jsonToProtobuf(receivedEvents.get(0).toString(),
+                TestServiceOuterClass.RandomSampleEvent.class);
+        assertThat(event.getId()).isEqualTo("some-id");
+        assertThat(event.getMessage()).isEqualTo("The message");
+    }
 }

--- a/src/main/java/com/sixt/service/framework/servicetest/mockservice/ServiceImpersonator.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/mockservice/ServiceImpersonator.java
@@ -19,6 +19,7 @@ import com.sixt.service.framework.MethodHandlerDictionary;
 import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.health.HealthCheckManager;
 import com.sixt.service.framework.injection.ServiceRegistryModule;
+import com.sixt.service.framework.injection.TracingModule;
 import com.sixt.service.framework.kafka.KafkaPublisher;
 import com.sixt.service.framework.kafka.KafkaPublisherFactory;
 import com.sixt.service.framework.protobuf.ProtobufUtil;
@@ -65,7 +66,7 @@ public class ServiceImpersonator {
         serviceProperties.setServiceName(serviceName); //has to be before getting regMgr
         serviceProperties.setServiceInstanceId(UUID.randomUUID().toString());
         serviceProperties.addProperty("registry", "consul");
-        injector = Guice.createInjector(testInjectionModule, new ServiceRegistryModule(serviceProperties));
+        injector = Guice.createInjector(testInjectionModule, new ServiceRegistryModule(serviceProperties), new TracingModule(serviceProperties));
         ServiceDiscoveryProvider provider = injector.getInstance(ServiceDiscoveryProvider.class);
         LoadBalancerFactory lbFactory = injector.getInstance(LoadBalancerFactory.class);
         lbFactory.initialize(provider);


### PR DESCRIPTION
The service integration tests broker because the service impersonator was missing the new tracing module.

Added a fix and also a simple test that makes use of an event handler and a service impersonator.