### PR TITLE
Extend ServiceImpersonator so you can ask it for events only by class…

### DIFF
--- a/src/main/java/com/sixt/service/framework/servicetest/eventing/ServiceTestEventHandler.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/eventing/ServiceTestEventHandler.java
@@ -110,6 +110,25 @@ public class ServiceTestEventHandler implements EventReceivedCallback<String> {
         return foundEvents;
     }
 
+    public <TYPE extends Message> List<TYPE> getEventsOfType(Class<TYPE> eventClass) {
+        List<TYPE> foundEvents = Lists.newArrayList();
+
+        if (eventClass != null) {
+            List<JsonObject> capturedEvents = Arrays.asList(readEvents.toArray(new JsonObject[0]));
+
+            for (JsonObject event : capturedEvents) {
+                logger.info("Found event: " + event.toString());
+                if (EventUtils.getEventName(event).equals(eventClass.getSimpleName())) {
+                    foundEvents.add(ProtobufUtil.jsonToProtobuf(event.toString(), eventClass));
+                    readEvents.remove(event);
+                }
+            }
+        } else {
+            logger.error("Event class is null");
+        }
+        return foundEvents;
+    }
+
     @SuppressWarnings("unchecked")
     public <T>T getEvent(String eventName, Class eventClass, Predicate<T> predicate, long timeout){
         long start = System.currentTimeMillis();

--- a/src/main/java/com/sixt/service/framework/servicetest/service/ServiceUnderTest.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/service/ServiceUnderTest.java
@@ -70,6 +70,15 @@ public interface ServiceUnderTest {
 
     <TYPE extends Message> List<TYPE> getEventsOfType(String eventName, Class<TYPE> eventClass);
 
+    /**
+     * Get a list of events from Kafka by the given event type class.
+     *
+     * @param eventClass The implementation of the {@link Message} interface e.g. VehicleUnlocked.class
+     * @param <TYPE> The type of the given event class.
+     * @return A list of events by the given type class.
+     */
+    <TYPE extends Message> List<TYPE> getEventsOfType(Class<TYPE> eventClass);
+
     List<JsonObject> getAllJsonEvents();
 
     /**

--- a/src/main/java/com/sixt/service/framework/servicetest/service/ServiceUnderTestImpl.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/service/ServiceUnderTestImpl.java
@@ -146,6 +146,17 @@ public class ServiceUnderTestImpl implements ServiceUnderTest {
     }
 
     @Override
+    public <TYPE extends Message> List<TYPE> getEventsOfType(Class<TYPE> eventClass) {
+
+        if (eventHandler == null) {
+            logger.warn("Event handler has not been initialized. Create the " +
+                    "ServiceUnderTest with true in the constructor.");
+            return new ArrayList<>();
+        }
+        return eventHandler.getEventsOfType(eventClass);
+    }
+
+    @Override
     public List<JsonObject> getAllJsonEvents() {
 
         if (eventHandler == null) {

--- a/src/test/java/com/sixt/service/framework/servicetest/eventing/ServiceTestEventHandlerTest.java
+++ b/src/test/java/com/sixt/service/framework/servicetest/eventing/ServiceTestEventHandlerTest.java
@@ -58,11 +58,19 @@ public class ServiceTestEventHandlerTest {
     }
 
     @Test
-    public void getEventsOfType_NoEvents() {
+    public void getEventsOfTypeIncludingEventName_NoEvents() {
         assertThat(eventHandler.kafkaSubscriber).isNotNull();
 
         List<TestEvent.OneTestEvent> foundEvents = eventHandler.getEventsOfType(ONE_TEST_EVENT_NAME, TestEvent.OneTestEvent.class);
         assertThat(foundEvents.isEmpty()).isTrue();
+    }
+
+    @Test
+    public void getEventsOfType_NoEvents() {
+        assertThat(eventHandler.kafkaSubscriber).isNotNull();
+
+        List<TestEvent.OneTestEvent> foundEvents = eventHandler.getEventsOfType(TestEvent.OneTestEvent.class);
+        assertThat(foundEvents).isEmpty();
     }
 
     @Test
@@ -98,12 +106,22 @@ public class ServiceTestEventHandlerTest {
     }
 
     @Test
-    public void getEventsOfType_EventsPresent() {
+    public void getEventsOfTypeIncludingEventName_EventsPresent() {
         eventHandler.kafkaSubscriber = mock(KafkaSubscriber.class);
         eventHandler.eventReceived(getOneTestEventBody(), new KafkaTopicInfo("topic", 0, 0, null));
 
         List<TestEvent.OneTestEvent> foundEvents = eventHandler.getEventsOfType(ONE_TEST_EVENT_NAME, TestEvent.OneTestEvent.class);
         assertThat(foundEvents.size()).isEqualTo(1);
+        verify(eventHandler.kafkaSubscriber).consume(any(KafkaTopicInfo.class));
+    }
+
+    @Test
+    public void getEventsOfType_EventsPresent() {
+        eventHandler.kafkaSubscriber = mock(KafkaSubscriber.class);
+        eventHandler.eventReceived(getOneTestEventBody(), new KafkaTopicInfo("topic", 0, 0, null));
+
+        List<TestEvent.OneTestEvent> foundEvents = eventHandler.getEventsOfType(TestEvent.OneTestEvent.class);
+        assertThat(foundEvents).hasSize(1);
         verify(eventHandler.kafkaSubscriber).consume(any(KafkaTopicInfo.class));
     }
 


### PR DESCRIPTION
… name (without additional event name). In many cases events are named after implementation classes. So it should be obvious to have a method to get events only by class name.