### PR TITLE
OSRE-317: staged test docker compose

### DIFF
--- a/sit/src/main/java/com/sixt/service/test_service/ServiceEntryPoint.java
+++ b/sit/src/main/java/com/sixt/service/test_service/ServiceEntryPoint.java
@@ -43,18 +43,6 @@ public class ServiceEntryPoint extends AbstractService {
 
     @Override
     public void bootstrapComplete() throws InterruptedException {
-
-        // To avoid sporadic test failures, we need to ensure the topics are created before we start the test service.
-        TopicVerification topicVerification = new TopicVerification();
-        Sleeper sleeper = new Sleeper();
-        String serviceName = serviceProperties.getServiceName();
-        Topic defaultInbox = Topic.defaultServiceInbox(serviceName);
-
-        Set<String> requiredTopics = ImmutableSet.of(defaultInbox.toString(), "events");
-        while(! topicVerification.verifyTopicsExist(serviceProperties.getKafkaServer(), requiredTopics, false)) {
-            sleeper.sleep(500);
-        }
-
         // Start a messaging consumer for the default inbox.
         ConsumerFactory consumerFactory = injector.getInstance(ConsumerFactory.class);
         consumerFactory.defaultInboxConsumer(new DiscardFailedMessages());

--- a/sit/src/serviceTest/java/com/sixt/service/test_service/MessagingServiceIntegrationTest.java
+++ b/sit/src/serviceTest/java/com/sixt/service/test_service/MessagingServiceIntegrationTest.java
@@ -19,6 +19,7 @@ import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.kafka.TopicVerification;
 import com.sixt.service.framework.kafka.messaging.*;
 import com.sixt.service.framework.servicetest.helper.DockerComposeHelper;
+import com.sixt.service.framework.servicetest.helper.StagedDockerComposeRule;
 import com.sixt.service.framework.util.Sleeper;
 import com.sixt.service.test_service.api.Echo;
 import com.sixt.service.test_service.api.Greeting;
@@ -40,15 +41,19 @@ import static org.junit.Assert.assertTrue;
 public class MessagingServiceIntegrationTest {
 
     @ClassRule
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    public static StagedDockerComposeRule docker = StagedDockerComposeRule.customBuilder()
             .file("src/serviceTest/resources/docker-compose.yml")
             .saveLogsTo("build/dockerCompose/logs")
+            .stage("kafka")
+            .service("kafka")
+            .waitingForService("kafka", (container) -> DockerComposeHelper.
+                    waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(3))
+            .stage("framework")
+            .service("consul")
             .waitingForService("consul", (container) -> DockerComposeHelper.
                     waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
-            .waitingForService("kafka", (container) -> DockerComposeHelper.
-                    waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(1))
-            .projectName(ProjectName.random())
             .build();
+
 
     @Rule
     public Timeout globalTimeout = Timeout.seconds(300);

--- a/sit/src/serviceTest/java/com/sixt/service/test_service/RandomServiceIntegrationTest.java
+++ b/sit/src/serviceTest/java/com/sixt/service/test_service/RandomServiceIntegrationTest.java
@@ -21,6 +21,7 @@ import com.sixt.service.framework.rpc.LoadBalancer;
 import com.sixt.service.framework.rpc.RpcCallException;
 import com.sixt.service.framework.rpc.ServiceEndpoint;
 import com.sixt.service.framework.servicetest.helper.DockerComposeHelper;
+import com.sixt.service.framework.servicetest.helper.StagedDockerComposeRule;
 import com.sixt.service.framework.servicetest.mockservice.ServiceImpersonator;
 import com.sixt.service.framework.servicetest.service.ServiceUnderTest;
 import com.sixt.service.framework.servicetest.service.ServiceUnderTestImpl;
@@ -42,14 +43,17 @@ public class RandomServiceIntegrationTest {
     private static ServiceUnderTest testService;
 
     @ClassRule
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    public static StagedDockerComposeRule docker = StagedDockerComposeRule.customBuilder()
             .file("src/serviceTest/resources/docker-compose.yml")
             .saveLogsTo("build/dockerCompose/logs")
-            .waitingForService("consul", (container) -> DockerComposeHelper.
-                    waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
+            .stage("kafka")
+            .service("kafka")
             .waitingForService("kafka", (container) -> DockerComposeHelper.
                     waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(3))
-            .projectName(ProjectName.random())
+            .stage("framework")
+            .service("consul")
+            .waitingForService("consul", (container) -> DockerComposeHelper.
+                    waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
             .build();
 
     private static ServiceImpersonator serviceImpersonator;

--- a/src/main/java/com/sixt/service/framework/servicetest/helper/DynamicFileLogCollector.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/helper/DynamicFileLogCollector.java
@@ -1,0 +1,105 @@
+package com.sixt.service.framework.servicetest.helper;
+
+
+import com.google.common.base.Preconditions;
+import com.palantir.docker.compose.execution.DockerCompose;
+import com.palantir.docker.compose.logging.LogCollector;
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * DynamicFileLogCollector allows to add services as they have been started to the set of monitored log files.
+ * <p>
+ * Precondition: services need to be started (docker-compose up) before you can capture their logs.
+ */
+public class DynamicFileLogCollector implements LogCollector {
+    // Partially copy-pasted from com.palantir.docker.compose.logging.FileLogCollector
+
+    private static final Logger log = LoggerFactory.getLogger(DynamicFileLogCollector.class);
+    private static final long STOP_TIMEOUT_IN_MILLIS = 50L;
+    private final File logDirectory;
+    private final ExecutorService executor = Executors.newCachedThreadPool(); // Creates an own thread for each log file to capture
+    private final Set<String> observedServices = new HashSet<>();
+
+    public DynamicFileLogCollector(File logDirectory) {
+        Preconditions.checkArgument(!logDirectory.isFile(), "Log directory cannot be a file");
+        if (!logDirectory.exists()) {
+            Validate.isTrue(logDirectory.mkdirs(), "Error making log directory: " + logDirectory.getAbsolutePath());
+        }
+
+        this.logDirectory = logDirectory;
+    }
+
+    public static DynamicFileLogCollector fromPath(String path) {
+        return new DynamicFileLogCollector(new File(path));
+    }
+
+
+    /**
+     * Collect logs of all services listed in the compose files.
+     *
+     * @param dockerCompose
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public synchronized void startCollecting(DockerCompose dockerCompose) throws IOException, InterruptedException {
+        for (String service : dockerCompose.services()) {
+            if (observedServices.contains(service)) {
+                continue;
+            }
+
+            observedServices.add(service);
+            collectLogs(service, dockerCompose);
+        }
+    }
+
+
+    /**
+     * Incrementally adds newly started services to the set of collected logs.
+     *
+     * @param dockerCompose
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public synchronized void startCollecting(DockerCompose dockerCompose, String service) throws IOException, InterruptedException {
+        if (observedServices.contains(service)) {
+            return;
+        }
+
+        observedServices.add(service);
+        collectLogs(service, dockerCompose);
+    }
+
+
+    private void collectLogs(String container, DockerCompose dockerCompose) {
+        executor.submit(() -> {
+            File outputFile = new File(logDirectory, container + ".log");
+            log.info("Writing logs for container '{}' to '{}'", container, outputFile.getAbsolutePath());
+            try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
+                dockerCompose.writeLogs(container, outputStream);  // docker-compose logs --follow
+            } catch (IOException e) {
+                throw new RuntimeException("Error reading log", e);
+            }
+        });
+    }
+
+    public synchronized void stopCollecting() throws InterruptedException {
+        // TODO: does this shut down policy really work: NO
+
+        if (!executor.awaitTermination(50L, TimeUnit.MILLISECONDS)) {
+            log.debug("docker containers were still running when log collection stopped");
+            executor.shutdownNow();
+        }
+    }
+}
+

--- a/src/main/java/com/sixt/service/framework/servicetest/helper/DynamicFileLogCollector.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/helper/DynamicFileLogCollector.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.sixt.service.framework.servicetest.helper;
 
 
@@ -44,7 +56,6 @@ public class DynamicFileLogCollector implements LogCollector {
         return new DynamicFileLogCollector(new File(path));
     }
 
-
     /**
      * Collect logs of all services listed in the compose files.
      *
@@ -62,7 +73,6 @@ public class DynamicFileLogCollector implements LogCollector {
             collectLogs(service, dockerCompose);
         }
     }
-
 
     /**
      * Incrementally adds newly started services to the set of collected logs.
@@ -94,8 +104,8 @@ public class DynamicFileLogCollector implements LogCollector {
     }
 
     public synchronized void stopCollecting() throws InterruptedException {
-        // TODO: does this shut down policy really work: NO
 
+        // This policy for a graceful shut down does not really work, but since we throw away the JVM, who cares?
         if (!executor.awaitTermination(50L, TimeUnit.MILLISECONDS)) {
             log.debug("docker containers were still running when log collection stopped");
             executor.shutdownNow();

--- a/src/main/java/com/sixt/service/framework/servicetest/helper/StagedDockerComposeRule.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/helper/StagedDockerComposeRule.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.sixt.service.framework.servicetest.helper;
 
 import com.palantir.docker.compose.DockerComposeRule;
@@ -21,7 +33,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Staged DockerCompose start up: multiple services and cluster waits can be bundled to a stage. A start up consists of

--- a/src/main/java/com/sixt/service/framework/servicetest/helper/StagedDockerComposeRule.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/helper/StagedDockerComposeRule.java
@@ -1,0 +1,335 @@
+package com.sixt.service.framework.servicetest.helper;
+
+import com.palantir.docker.compose.DockerComposeRule;
+import com.palantir.docker.compose.configuration.DockerComposeFiles;
+import com.palantir.docker.compose.configuration.ProjectName;
+import com.palantir.docker.compose.connection.Cluster;
+import com.palantir.docker.compose.connection.Container;
+import com.palantir.docker.compose.connection.DockerPort;
+import com.palantir.docker.compose.connection.waiting.ClusterHealthCheck;
+import com.palantir.docker.compose.connection.waiting.ClusterWait;
+import com.palantir.docker.compose.connection.waiting.HealthCheck;
+import com.palantir.docker.compose.execution.ConflictingContainerRemovingDockerCompose;
+import com.palantir.docker.compose.execution.Docker;
+import com.palantir.docker.compose.execution.DockerCompose;
+import com.palantir.docker.compose.logging.LogCollector;
+import org.joda.time.ReadableDuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Staged DockerCompose start up: multiple services and cluster waits can be bundled to a stage. A start up consists of
+ * multiple stages that are executed in order: all services of a stage are started (the equivalent of docker-compose up -d name) and
+ * all waits are executed. Then the rule proceeds with the next stage.
+ * <p>
+ * There is a default stage that takes all waits not explicitly assigned to a stage.
+ */
+public class StagedDockerComposeRule extends DockerComposeRule {
+
+    /*
+        Implementation note:
+        DockerComposeRule uses immutables.github.io to generate ImmutableDockerComposeRule which is the concrete class users interact with.
+        This makes the extension of DockerComposeRule a fairly unpleasant job since we don't want to use code generation here.
+
+        Here's what you need to do:
+        For each attribute you want to set in the StagedDockerComposeRule, add methods to the Builder and transfer them to
+        the StagedDockerComposeRule via constructor. In addition, you need to override the getter method specifying a default
+        in the base class.
+
+     */
+
+    private static final Logger log = LoggerFactory.getLogger(DockerComposeRule.class);
+
+    private final ProjectName projectName;
+    private final DockerComposeFiles files;
+    private final DynamicFileLogCollector logCollector;
+
+    private final List<Stage> stages;
+
+    /**
+     * Build by StagedDockerComposeRule.Builder
+     *
+     * @param files
+     * @param logCollector
+     * @param stages
+     */
+    StagedDockerComposeRule(ProjectName name, DockerComposeFiles files, DynamicFileLogCollector logCollector, List<Stage> stages) {
+        this.projectName = name;
+        this.files = files;
+        this.stages = Collections.unmodifiableList(stages);
+        this.logCollector = logCollector;
+    }
+
+    @Override
+    public DockerComposeFiles files() {
+        return files;
+    }
+
+
+    @Override
+    public ProjectName projectName() {
+        return projectName;
+    }
+
+    @Override
+    public LogCollector logCollector() {
+        return logCollector;
+    }
+
+
+    @Override
+    @Deprecated
+    protected List<ClusterWait> clusterWaits() {
+        throw new UnsupportedOperationException("Unsupported operation since a global list of waits does not make sense in this context.");
+    }
+
+    // Test access
+    List<Stage> stages() {
+        return Collections.unmodifiableList(stages);
+    }
+
+    @Override
+    public void before() throws IOException, InterruptedException {
+        // Partially copy-pasted from com.palantir.docker.compose.DockerComposeRule
+
+        log.debug("Starting docker-compose cluster");
+
+        Docker docker = docker();
+        DockerCompose dockerCompose = dockerCompose();
+
+        if (pullOnStartup()) {
+            dockerCompose.pull();
+        }
+        dockerCompose.build();
+
+        if (removeConflictingContainersOnStartup()) {
+            dockerCompose = new ConflictingContainerRemovingDockerCompose(dockerCompose, docker);
+        }
+
+
+        for (Stage stage : stages) {
+            log.debug("Starting stage {}", stage.getName());
+
+            if (stage.getServices().isEmpty()) {
+                // the default stage that contains all not explicitly mentioned services
+                // we do a unqualified docker-compose up
+                dockerCompose.up();
+                log.debug("Starting all remaining services");
+                logCollector.startCollecting(dockerCompose);
+            } else {
+                for (String service : stage.getServices()) {
+                    Container serviceContainer = new Container(service, docker, dockerCompose);
+                    dockerCompose.up(serviceContainer);
+                    log.debug("Starting service {}", service);
+
+                    // TODO: do we have a race between docker-compose up and docker-compose logs ??
+
+                    // Incrementally add newly started services to the set of collected logs.
+                    logCollector.startCollecting(dockerCompose, service);
+                }
+            }
+
+            Cluster containers = this.containers();
+
+            ClusterWait nativeHealthCheck = new ClusterWait(ClusterHealthCheck.nativeHealthChecks(), this.nativeServiceHealthCheckTimeout());
+            nativeHealthCheck.waitUntilReady(containers);
+
+            for (ClusterWait clusterWait : stage.getWaits()) {
+                clusterWait.waitUntilReady(containers);
+            }
+
+            log.debug("Waiting for services of stage {}", stage.getName());
+        }
+
+        log.debug("docker-compose cluster started");
+    }
+
+
+    public static Builder customBuilder() {
+        return new Builder();
+    }
+
+    @Deprecated
+    public static DockerComposeRule.Builder builder() {
+        throw new UnsupportedOperationException("Use customBuilder instead.");
+    }
+
+    public static class Builder {
+        // Part of this Build was copy-pasted from com.palantir.docker.compose.DockerComposeRule.Builder
+
+        private final List<Stage> stages = new ArrayList<>();
+        private final Stage defaultStage = new Stage("default");
+        private Stage currentExplicitStage = null;
+
+        private DynamicFileLogCollector logCollector;
+        private DockerComposeFiles files;
+        private ProjectName projectName = ProjectName.random();
+
+        // Global settings
+
+        public Builder file(String dockerComposeYmlFile) {
+            if (files != null) {
+                throw new IllegalStateException("Files is already set.");
+            }
+            files = DockerComposeFiles.from(new String[]{dockerComposeYmlFile});
+            return this;
+        }
+
+        public Builder saveLogsTo(String path) {
+            if (logCollector != null) {
+                throw new IllegalStateException("Log file path is alreay set.");
+            }
+            logCollector = DynamicFileLogCollector.fromPath(path);
+            return this;
+        }
+
+        public Builder projectName(ProjectName name) {
+            projectName = name;
+            return this;
+        }
+
+        /**
+         * @throws UnsupportedOperationException
+         * @deprecated
+         */
+        @Deprecated
+        public Builder skipShutdown(boolean skipShutdown) {
+            throw new UnsupportedOperationException("skipShutdown no longer supported");
+        }
+
+        // Waits can be applied either to an explict stage or the default stage.
+
+        public Builder waitingForService(String serviceName, HealthCheck<Container> healthCheck) {
+            return this.waitingForService(serviceName, healthCheck, DockerComposeRule.DEFAULT_TIMEOUT);
+        }
+
+        public Builder waitingForService(String serviceName, HealthCheck<Container> healthCheck, ReadableDuration timeout) {
+            ClusterHealthCheck clusterHealthCheck = ClusterHealthCheck.serviceHealthCheck(serviceName, healthCheck);
+            return this.addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
+        }
+
+        public Builder waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck) {
+            return this.waitingForServices(services, healthCheck, DockerComposeRule.DEFAULT_TIMEOUT);
+        }
+
+        public Builder waitingForServices(List<String> services, HealthCheck<List<Container>> healthCheck, ReadableDuration timeout) {
+            ClusterHealthCheck clusterHealthCheck = ClusterHealthCheck.serviceHealthCheck(services, healthCheck);
+            return this.addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
+        }
+
+        public Builder waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck) {
+            return this.waitingForHostNetworkedPort(port, healthCheck, DockerComposeRule.DEFAULT_TIMEOUT);
+        }
+
+        public Builder waitingForHostNetworkedPort(int port, HealthCheck<DockerPort> healthCheck, ReadableDuration timeout) {
+            ClusterHealthCheck clusterHealthCheck = ClusterHealthCheck.transformingHealthCheck((cluster) -> {
+                return new DockerPort(cluster.ip(), port, port);
+            }, healthCheck);
+            return this.addClusterWait(new ClusterWait(clusterHealthCheck, timeout));
+        }
+
+        public Builder clusterWaits(Iterable<? extends ClusterWait> elements) {
+            return this.addAllClusterWaits(elements);
+        }
+
+        private Builder addAllClusterWaits(Iterable<? extends ClusterWait> elements) {
+            for (ClusterWait clusterWait : elements) {
+                this.addClusterWait(clusterWait);
+            }
+            return this;
+        }
+
+        private Builder addClusterWait(ClusterWait clusterWait) {
+            activeStage().addClusterWait(clusterWait);
+            return this;
+        }
+
+        // Staging
+
+        /**
+         * Opens a stage to start one or multiple services.
+         *
+         * @param name
+         * @return
+         */
+        public Builder stage(String name) {
+            currentExplicitStage = new Stage(name);
+            stages.add(currentExplicitStage);
+            return this;
+        }
+
+        /**
+         * End the current explicit stage and put everything into default stage from now on.
+         */
+        public Builder defaultStage() {
+            currentExplicitStage = null;
+            return this;
+        }
+
+        private Stage activeStage() {
+            return currentExplicitStage != null ? currentExplicitStage : defaultStage;
+        }
+
+        /**
+         * Adds a service to a stage.
+         *
+         * @param service the name of the service as specified in the docker compose files.
+         * @return
+         */
+        public Builder service(String service) {
+            if (currentExplicitStage == null) {
+                throw new IllegalStateException("You need to open a stage if you want start a service explicitly.");
+            }
+
+            currentExplicitStage.addService(service);
+            return this;
+        }
+
+        public StagedDockerComposeRule build() {
+            // default stage is always executed and the last stage in the chain
+            stages.add(defaultStage);
+
+            return new StagedDockerComposeRule(projectName, files, logCollector, stages);
+        }
+    }
+
+
+    static class Stage {
+
+        final List<String> services = new ArrayList<>();
+
+        final List<ClusterWait> waits = new ArrayList<>();
+
+        final String name;
+
+        Stage(String name) {
+            this.name = name;
+        }
+
+        List<String> getServices() {
+            return services;
+        }
+
+        List<ClusterWait> getWaits() {
+            return waits;
+        }
+
+        String getName() {
+            return name;
+        }
+
+        void addService(String service) {
+            services.add(service);
+        }
+
+        void addClusterWait(ClusterWait clusterWait) {
+            waits.add(clusterWait);
+        }
+    }
+}

--- a/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaFailoverIntegrationTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaFailoverIntegrationTest.java
@@ -19,6 +19,7 @@ import com.sixt.service.framework.IntegrationTest;
 import com.sixt.service.framework.OrangeContext;
 import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.servicetest.helper.DockerComposeHelper;
+import com.sixt.service.framework.servicetest.helper.StagedDockerComposeRule;
 import com.sixt.service.framework.util.Sleeper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.joda.time.Duration;
@@ -52,10 +53,9 @@ public class KafkaFailoverIntegrationTest {
 
 
     @ClassRule
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    public static StagedDockerComposeRule docker = StagedDockerComposeRule.customBuilder()
             .file("src/test/resources/docker-compose-kafkafailover-integrationtest.yml")
             .saveLogsTo("build/dockerCompose/logs")
-            .projectName(ProjectName.random())
             .waitingForService("kafka1", (container) -> DockerComposeHelper.waitForKafka(
                     "build/dockerCompose/logs/kafka1.log"), Duration.standardMinutes(2))
             .waitingForService("kafka2", (container) -> DockerComposeHelper.waitForKafka(

--- a/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
@@ -18,6 +18,7 @@ import com.sixt.service.framework.IntegrationTest;
 import com.sixt.service.framework.OrangeContext;
 import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.servicetest.helper.DockerComposeHelper;
+import com.sixt.service.framework.servicetest.helper.StagedDockerComposeRule;
 import com.sixt.service.framework.util.Sleeper;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.joda.time.Duration;
@@ -46,10 +47,9 @@ public class KafkaIntegrationTest {
     public Timeout globalTimeout = Timeout.seconds(300);
 
     @ClassRule
-    public static DockerComposeRule docker = DockerComposeRule.builder()
+    public static StagedDockerComposeRule docker = StagedDockerComposeRule.customBuilder()
             .file("src/test/resources/docker-compose-integrationtest.yml")
             .saveLogsTo("build/dockerCompose/logs")
-            .projectName(ProjectName.random())
             .waitingForService("kafka", (container) -> DockerComposeHelper.waitForKafka(
                     "build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(2))
             .build();

--- a/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Ignore //Ignore until we can properly fix the kafka SIT issue
 @Category(IntegrationTest.class)
 public class KafkaIntegrationTest {
     private static final Logger logger = LoggerFactory.getLogger(KafkaIntegrationTest.class);

--- a/src/test/java/com/sixt/service/framework/servicetest/helper/StagedDockerComposeRuleTest.java
+++ b/src/test/java/com/sixt/service/framework/servicetest/helper/StagedDockerComposeRuleTest.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.sixt.service.framework.servicetest.helper;
 
 import com.palantir.docker.compose.configuration.ProjectName;

--- a/src/test/java/com/sixt/service/framework/servicetest/helper/StagedDockerComposeRuleTest.java
+++ b/src/test/java/com/sixt/service/framework/servicetest/helper/StagedDockerComposeRuleTest.java
@@ -1,0 +1,228 @@
+package com.sixt.service.framework.servicetest.helper;
+
+import com.palantir.docker.compose.configuration.ProjectName;
+import org.joda.time.Duration;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@Ignore("Takes several minutes to run. Test if containers really start is not automated.")
+public class StagedDockerComposeRuleTest {
+
+    private final static Logger log = LoggerFactory.getLogger(StagedDockerComposeRuleTest.class);
+
+
+    @Test
+    public void useWithoutStages() throws IOException, InterruptedException {
+        // No stages -> all should go to default stage
+        StagedDockerComposeRule sdcr = StagedDockerComposeRule.customBuilder()
+                .file("sit/src/serviceTest/resources/docker-compose.yml")
+                .saveLogsTo("build/dockerCompose/logs")
+                .waitingForService("consul", (container) -> DockerComposeHelper.
+                        waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
+                .waitingForService("kafka", (container) -> DockerComposeHelper.
+                        waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(2))
+                .projectName(ProjectName.fromString("cruft"))
+                .build();
+
+        List<StagedDockerComposeRule.Stage> stages = sdcr.stages();
+        assertEquals(1, stages.size());
+
+        StagedDockerComposeRule.Stage defaultStage = stages.get(0);
+        assertEquals("default", defaultStage.getName());
+        assertEquals(0, defaultStage.getServices().size());
+        assertEquals(2, defaultStage.getWaits().size());
+
+        try {
+            log.debug("pre before()");
+            sdcr.before();
+            log.debug("post before()");
+
+        } finally {
+            log.debug("pre after()");
+            sdcr.after();
+            log.debug("post after()");
+        }
+
+    }
+
+
+    @Test
+    public void useExplicitStage() throws IOException, InterruptedException {
+        StagedDockerComposeRule sdcr = StagedDockerComposeRule.customBuilder()
+                .file("sit/src/serviceTest/resources/docker-compose.yml")  // Global setting
+                .stage("infrastructure") // Opens a stage -> current stage
+                .service("kafka") // Binds to current stage
+                .service("consul") // Binds to current stage
+                .waitingForService("kafka", (container) -> DockerComposeHelper.
+                        waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(3)) // Binds to current stage
+                .waitingForService("consul", (container) -> DockerComposeHelper.
+                        waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1)) // Binds to current stage
+                // remaining services start in default stage
+                .saveLogsTo("build/dockerCompose/logs") // Global setting
+                .build();
+
+        List<StagedDockerComposeRule.Stage> stages = sdcr.stages();
+        assertEquals(2, stages.size());
+
+        StagedDockerComposeRule.Stage explictStage = stages.get(0);
+        assertEquals("infrastructure", explictStage.getName());
+        assertEquals(2, explictStage.getServices().size());
+        assertEquals(2, explictStage.getWaits().size());
+
+
+        StagedDockerComposeRule.Stage defaultStage = stages.get(1);
+        assertEquals("default", defaultStage.getName());
+        assertEquals(0, defaultStage.getServices().size());
+        assertEquals(0, defaultStage.getWaits().size());
+
+        try {
+            log.debug("pre before()");
+            sdcr.before();
+            log.debug("post before()");
+
+        } finally {
+            log.debug("pre after()");
+            sdcr.after();
+            log.debug("post after()");
+        }
+    }
+
+
+    @Test
+    public void useMultipleStages() throws IOException, InterruptedException {
+        StagedDockerComposeRule sdcr = StagedDockerComposeRule.customBuilder()
+                .file("sit/src/serviceTest/resources/docker-compose.yml")  // Global setting
+                .stage("kafka")
+                .service("kafka")
+                .saveLogsTo("build/dockerCompose/logs") // Global setting, mixed in at any point
+                .waitingForService("kafka", (container) -> DockerComposeHelper.
+                        waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(3))
+                .stage("framework")
+                .service("consul") // Binds to current stage
+                .waitingForService("consul", (container) -> DockerComposeHelper.
+                        waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
+                .stage("SUT") // Should be not required -> default stage, includes all remaining services (i.e. unqualified compose up)
+                .build();
+
+        List<StagedDockerComposeRule.Stage> stages = sdcr.stages();
+        assertEquals(4, stages.size());
+
+        StagedDockerComposeRule.Stage explictStage = stages.get(0);
+        assertEquals("kafka", explictStage.getName());
+        assertEquals(1, explictStage.getServices().size());
+        assertEquals(1, explictStage.getWaits().size());
+
+        explictStage = stages.get(1);
+        assertEquals("framework", explictStage.getName());
+        assertEquals(1, explictStage.getServices().size());
+        assertEquals(1, explictStage.getWaits().size());
+
+        explictStage = stages.get(2);
+        assertEquals("SUT", explictStage.getName());
+        assertEquals(0, explictStage.getServices().size());
+        assertEquals(0, explictStage.getWaits().size());
+
+        StagedDockerComposeRule.Stage defaultStage = stages.get(3);
+        assertEquals("default", defaultStage.getName());
+        assertEquals(0, defaultStage.getServices().size());
+        assertEquals(0, defaultStage.getWaits().size());
+
+        try {
+            log.debug("pre before()");
+            sdcr.before();
+            log.debug("post before()");
+
+        } finally {
+            log.debug("pre after()");
+            sdcr.after();
+            log.debug("post after()");
+        }
+    }
+
+
+    @Test
+    public void mixingDefaultAndExplicitStage_noExplictDefault() throws IOException, InterruptedException {
+        StagedDockerComposeRule sdcr = StagedDockerComposeRule.customBuilder()
+                .file("sit/src/serviceTest/resources/docker-compose.yml")  // Global setting
+                .waitingForService("consul", (container) -> DockerComposeHelper.  // Binds to default stage which is executed after the explicit stage.
+                        waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
+                .stage("infrastructure") // Opens a stage -> current stage
+                .service("kafka") // Binds to stage infrastructure
+                .waitingForService("kafka", (container) -> DockerComposeHelper.
+                        waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(3)) // Binds to stage infrastructure
+                // remaining services start in default stage
+                .saveLogsTo("build/dockerCompose/logs") // Global setting
+                .build();
+
+        List<StagedDockerComposeRule.Stage> stages = sdcr.stages();
+        assertEquals(2, stages.size());
+
+        StagedDockerComposeRule.Stage explictStage = stages.get(0);
+        assertEquals("infrastructure", explictStage.getName());
+        assertEquals(1, explictStage.getServices().size());
+        assertEquals(1, explictStage.getWaits().size());
+
+        StagedDockerComposeRule.Stage defaultStage = stages.get(1);
+        assertEquals("default", defaultStage.getName());
+        assertEquals(0, defaultStage.getServices().size());
+        assertEquals(1, defaultStage.getWaits().size());
+
+        try {
+            log.debug("pre before()");
+            sdcr.before();
+            log.debug("post before()");
+
+        } finally {
+            log.debug("pre after()");
+            sdcr.after();
+            log.debug("post after()");
+        }
+    }
+
+
+    @Test
+    public void mixingDefaultAndExplicitStage_ExplictDefault() throws IOException, InterruptedException {
+        StagedDockerComposeRule sdcr = StagedDockerComposeRule.customBuilder()
+                .file("sit/src/serviceTest/resources/docker-compose.yml")  // Global setting
+                .saveLogsTo("build/dockerCompose/logs") // Global setting
+                .stage("infrastructure") // Opens a stage -> current stage
+                .service("kafka") // Binds to stage infrastructure
+                .waitingForService("kafka", (container) -> DockerComposeHelper.
+                        waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(3)) // Binds to stage infrastructure
+                .defaultStage() // open explicit context for default stage
+                .waitingForService("consul", (container) -> DockerComposeHelper.  // Binds to default stage which is executed after the explicit stage.
+                        waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
+                .build();
+
+        List<StagedDockerComposeRule.Stage> stages = sdcr.stages();
+        assertEquals(2, stages.size());
+
+        StagedDockerComposeRule.Stage explictStage = stages.get(0);
+        assertEquals("infrastructure", explictStage.getName());
+        assertEquals(1, explictStage.getServices().size());
+        assertEquals(1, explictStage.getWaits().size());
+
+        StagedDockerComposeRule.Stage defaultStage = stages.get(1);
+        assertEquals("default", defaultStage.getName());
+        assertEquals(0, defaultStage.getServices().size());
+        assertEquals(1, defaultStage.getWaits().size());
+
+        try {
+            log.debug("pre before()");
+            sdcr.before();
+            log.debug("post before()");
+
+        } finally {
+            log.debug("pre after()");
+            sdcr.after();
+            log.debug("post after()");
+        }
+    }
+}


### PR DESCRIPTION
Fix a race condition in the start up of the service integration tests (see OSRE-317).

By introducing the StagedDockerComposeRule we can start up the test environment in several stages, e.g. first the infrastructure including Kafka, then the service under test.