### PR TITLE
Healthchecks for ordered Kafka ramp up in integration tests.

### DIFF
--- a/sit/src/main/java/com/sixt/service/test_service/ServiceEntryPoint.java
+++ b/sit/src/main/java/com/sixt/service/test_service/ServiceEntryPoint.java
@@ -43,18 +43,6 @@ public class ServiceEntryPoint extends AbstractService {
 
     @Override
     public void bootstrapComplete() throws InterruptedException {
-
-        // To avoid sporadic test failures, we need to ensure the topics are created before we start the test service.
-        TopicVerification topicVerification = new TopicVerification();
-        Sleeper sleeper = new Sleeper();
-        String serviceName = serviceProperties.getServiceName();
-        Topic defaultInbox = Topic.defaultServiceInbox(serviceName);
-
-        Set<String> requiredTopics = ImmutableSet.of(defaultInbox.toString(), "events");
-        while(! topicVerification.verifyTopicsExist(serviceProperties.getKafkaServer(), requiredTopics, false)) {
-            sleeper.sleep(500);
-        }
-
         // Start a messaging consumer for the default inbox.
         ConsumerFactory consumerFactory = injector.getInstance(ConsumerFactory.class);
         consumerFactory.defaultInboxConsumer(new DiscardFailedMessages());

--- a/sit/src/serviceTest/java/com/sixt/service/test_service/MessagingServiceIntegrationTest.java
+++ b/sit/src/serviceTest/java/com/sixt/service/test_service/MessagingServiceIntegrationTest.java
@@ -39,15 +39,13 @@ import static org.junit.Assert.assertTrue;
 
 public class MessagingServiceIntegrationTest {
 
+    // Nota bene: the DockerComposeRule automaticaly checks the healthcheck status of services (if defined).
     @ClassRule
     public static DockerComposeRule docker = DockerComposeRule.builder()
             .file("src/serviceTest/resources/docker-compose.yml")
             .saveLogsTo("build/dockerCompose/logs")
             .waitingForService("consul", (container) -> DockerComposeHelper.
                     waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
-            .waitingForService("kafka", (container) -> DockerComposeHelper.
-                    waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(1))
-            .projectName(ProjectName.random())
             .build();
 
     @Rule

--- a/sit/src/serviceTest/java/com/sixt/service/test_service/RandomServiceIntegrationTest.java
+++ b/sit/src/serviceTest/java/com/sixt/service/test_service/RandomServiceIntegrationTest.java
@@ -47,9 +47,6 @@ public class RandomServiceIntegrationTest {
             .saveLogsTo("build/dockerCompose/logs")
             .waitingForService("consul", (container) -> DockerComposeHelper.
                     waitForConsul("build/dockerCompose/logs/consul.log"), Duration.standardMinutes(1))
-            .waitingForService("kafka", (container) -> DockerComposeHelper.
-                    waitForKafka("build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(3))
-            .projectName(ProjectName.random())
             .build();
 
     private static ServiceImpersonator serviceImpersonator;

--- a/sit/src/serviceTest/resources/docker-compose.yml
+++ b/sit/src/serviceTest/resources/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.1"
 
 services:
   com.sixt.service.test-service:
@@ -15,9 +15,12 @@ services:
       - "5005"
       - "42000"
     depends_on:
-      - zookeeper
-      - consul
-      - kafka
+      zookeeper:
+        condition: service_started
+      consul:
+        condition: service_started
+      kafka:
+        condition: service_healthy
 
   consul:
     image: consul:0.7.5
@@ -38,9 +41,8 @@ services:
       - "9092"
     environment:
       KAFKA_ADVERTISED_PORT: 9092
-      KAFKA_CREATE_TOPICS: "inbox_test:3:1,inbox-com.sixt.service.test-service:3:1,events:1:1" # events should be last
+      KAFKA_CREATE_TOPICS: "inbox_test:3:1,inbox-com.sixt.service.test-service:3:1,events:1:1" # events must be last for the healthcheck to work
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      # Disable topic auto creation -> otherwise we have an occasional concurrency bug in the tests
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -49,3 +51,9 @@ services:
       - "zookeeper"
     entrypoint: /tmp/start_kafka.sh
     hostname: kafka
+    healthcheck:
+      # nota bene: test command is executed inside the container
+      test: ["CMD-SHELL", "/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --zookeeper zookeeper:2181 --list | grep 'events$$' "]
+      interval: 10s  # test is executed every 10s
+      timeout: 10s   # timeout per test cmd
+      retries: 12    # try 12*10s = 120s = 2min

--- a/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaFailoverIntegrationTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaFailoverIntegrationTest.java
@@ -40,8 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertTrue;
 
-// This test is not automated and meant to be run manually: you kill/restart some Docker containers, look to the logs and see what happens.
-@Ignore
+@Ignore("This test is not automated and meant to be run manually: you kill/restart some Docker containers, look to the logs and see what happens.")
 @Category(IntegrationTest.class)
 public class KafkaFailoverIntegrationTest {
 

--- a/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Ignore //Ignore until we can properly fix the kafka SIT issue
 @Category(IntegrationTest.class)
 public class KafkaIntegrationTest {
     private static final Logger logger = LoggerFactory.getLogger(KafkaIntegrationTest.class);
@@ -49,9 +48,6 @@ public class KafkaIntegrationTest {
     public static DockerComposeRule docker = DockerComposeRule.builder()
             .file("src/test/resources/docker-compose-integrationtest.yml")
             .saveLogsTo("build/dockerCompose/logs")
-            .projectName(ProjectName.random())
-            .waitingForService("kafka", (container) -> DockerComposeHelper.waitForKafka(
-                    "build/dockerCompose/logs/kafka.log"), Duration.standardMinutes(2))
             .build();
 
     @BeforeClass

--- a/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
@@ -113,6 +113,7 @@ public class KafkaIntegrationTest {
         replyConsumer.shutdown();
     }
 
+    @Ignore("long running test")
     @Test
     public void partitionAssignmentChange() throws InterruptedException {
         ServiceProperties serviceProperties = new ServiceProperties();

--- a/src/test/resources/docker-compose-integrationtest.yml
+++ b/src/test/resources/docker-compose-integrationtest.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.1"
 
 services:
   zookeeper:

--- a/src/test/resources/docker-compose-integrationtest.yml
+++ b/src/test/resources/docker-compose-integrationtest.yml
@@ -14,8 +14,8 @@ services:
     environment:
       KAFKA_ADVERTISED_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_CREATE_TOPICS: "ping:3:1,pong:3:1,events:3:1"
+      KAFKA_CREATE_TOPICS: "ping:3:1,pong:3:1,events:3:1" # events mjust be last
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./scripts/start_kafka.sh:/tmp/start_kafka.sh
@@ -23,3 +23,10 @@ services:
       - zookeeper
     entrypoint: /tmp/start_kafka.sh
     hostname: kafka
+    healthcheck:
+      # nota bene: test command is executed inside the container
+      # the DockerComposeRule will check if this services goes to state healthy by this healthcheck
+      test: ["CMD-SHELL", "/opt/kafka_2.11-0.10.1.0/bin/kafka-topics.sh --zookeeper zookeeper:2181 --list | grep 'events$$' "]
+      interval: 10s  # test is executed every 10s
+      timeout: 10s   # timeout per test cmd
+      retries: 12    # try 12*10s = 120s = 2min


### PR DESCRIPTION
Added healthchecks to docker-compose files (version 2.1 required, works with docker-compose 1.11.2).
Activated tests that were ignored because of the Kafka issue.
Removed topic checks from test service bootstrap.

See also OSRE-317