### PR TITLE
remove newArrayList and newHashMap calls

### DIFF
--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
@@ -1,18 +1,17 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
 package com.sixt.service.framework.kafka;
 
-import com.google.common.collect.Lists;
 import com.google.protobuf.Message;
 import com.sixt.service.framework.protobuf.ProtobufUtil;
 import com.sixt.service.framework.util.ReflectionUtil;
@@ -111,7 +110,11 @@ public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListene
             props.put("enable.auto.commit", Boolean.toString(enableAutoCommit));
             props.put("auto.offset.reset", offsetReset.toString().toLowerCase());
             realConsumer = new KafkaConsumer<>(props);
-            realConsumer.subscribe(Lists.newArrayList(topic), this);
+
+            List<String> topics = new ArrayList<String>();
+            topics.add(topic);
+            realConsumer.subscribe(topics, this);
+
             offsetCommitter = new OffsetCommitter(realConsumer, Clock.systemUTC());
             primaryExecutor = Executors.newSingleThreadExecutor();
             primaryExecutor.submit(this);

--- a/src/main/java/com/sixt/service/framework/kafka/messaging/Consumer.java
+++ b/src/main/java/com/sixt/service/framework/kafka/messaging/Consumer.java
@@ -12,7 +12,6 @@
 
 package com.sixt.service.framework.kafka.messaging;
 
-import com.google.common.collect.Lists;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -107,7 +106,10 @@ public final class Consumer {
         @Override
         public void run() {
             try {
-                kafka.subscribe(Lists.newArrayList(topic.toString()), new PartitionAssignmentChange());
+                List<String> topics = new ArrayList<>();
+                topics.add(topic.toString());
+
+                kafka.subscribe(topics, new PartitionAssignmentChange());
                 logger.info("Consumer in group {} subscribed to topic {}", consumerGroupId, topic.toString());
             } catch (Exception unexpected) {
                 logger.error("Dead consumer in group {}: Cannot subscribe to topic {}", consumerGroupId, topic.toString(), unexpected);

--- a/src/main/java/com/sixt/service/framework/servicetest/eventing/EventFinder.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/eventing/EventFinder.java
@@ -1,25 +1,25 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
 package com.sixt.service.framework.servicetest.eventing;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.gson.JsonObject;
 import com.google.protobuf.Message;
 import com.sixt.service.framework.protobuf.ProtobufUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -39,8 +39,8 @@ public class EventFinder implements Callable<Map<String, Message>> {
     @SuppressWarnings("unchecked")
     @Override
     public Map<String, Message> call() throws Exception {
-        Map<String, Message> foundEvents = Maps.newHashMap();
-        List<JsonObject> capturedEvents = Lists.newArrayList();
+        Map<String, Message> foundEvents = new HashMap<>();
+        List<JsonObject> capturedEvents = new ArrayList<>();
 
         while (foundEvents.size() != expectedEvents.size()) {
             logger.info("Polling kafka...");

--- a/src/main/java/com/sixt/service/framework/servicetest/eventing/ServiceTestEventHandler.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/eventing/ServiceTestEventHandler.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
@@ -92,7 +92,7 @@ public class ServiceTestEventHandler implements EventReceivedCallback<String> {
     }
 
     public <TYPE extends Message> List<TYPE> getEventsOfType(String eventName, Class<TYPE> eventClass) {
-        List<TYPE> foundEvents = Lists.newArrayList();
+        List<TYPE> foundEvents = new ArrayList<>();
 
         if (eventName != null && eventClass != null) {
             List<JsonObject> capturedEvents = Arrays.asList(readEvents.toArray(new JsonObject[0]));
@@ -111,7 +111,7 @@ public class ServiceTestEventHandler implements EventReceivedCallback<String> {
     }
 
     public <TYPE extends Message> List<TYPE> getEventsOfType(Class<TYPE> eventClass) {
-        List<TYPE> foundEvents = Lists.newArrayList();
+        List<TYPE> foundEvents = new ArrayList<>();
 
         if (eventClass != null) {
             List<JsonObject> capturedEvents = Arrays.asList(readEvents.toArray(new JsonObject[0]));

--- a/src/main/java/com/sixt/service/framework/servicetest/helper/DockerComposeHelper.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/helper/DockerComposeHelper.java
@@ -1,18 +1,17 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
 package com.sixt.service.framework.servicetest.helper;
 
-import com.google.common.collect.Maps;
 import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.connection.waiting.SuccessOrFailure;
@@ -26,6 +25,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class DockerComposeHelper {
@@ -38,7 +38,7 @@ public class DockerComposeHelper {
      */
     public static void setKafkaEnvironment(DockerComposeRule docker) {
         DockerPort kafka = docker.containers().container("kafka").port(9092);
-        Map<String, String> newEnv = Maps.newHashMap();
+        Map<String, String> newEnv = new HashMap<>();
         newEnv.put(ServiceProperties.KAFKA_SERVER_KEY, kafka.inFormat("$HOST:$EXTERNAL_PORT"));
         newEnv.putAll(System.getenv());
         setEnv(newEnv);
@@ -50,7 +50,7 @@ public class DockerComposeHelper {
      */
     public static void setConsulEnvironment(DockerComposeRule docker) {
         DockerPort consul = docker.containers().container("consul").port(8500);
-        Map<String, String> newEnv = Maps.newHashMap();
+        Map<String, String> newEnv = new HashMap<>();
         newEnv.put(ServiceProperties.REGISTRY_SERVER_KEY, consul.inFormat("$HOST:$EXTERNAL_PORT"));
         newEnv.putAll(System.getenv());
         setEnv(newEnv);
@@ -62,7 +62,7 @@ public class DockerComposeHelper {
      */
     public static void setEtcdEnvironment(DockerComposeRule docker) {
         DockerPort etcd = docker.containers().container("etcd").port(2379);
-        Map<String, String> newEnv = Maps.newHashMap();
+        Map<String, String> newEnv = new HashMap<>();
         newEnv.put("etcd_endpoints", etcd.inFormat("http://$HOST:$EXTERNAL_PORT"));
         newEnv.putAll(System.getenv());
         setEnv(newEnv);
@@ -165,7 +165,7 @@ public class DockerComposeHelper {
     public static SuccessOrFailure waitForDynamoDb(String logFile) {
         return waitFor(logFile, "CorsParams:", "Dynamo DB not ready yet");
     }
-    
+
     private static SuccessOrFailure waitFor(String logFile, String expected, String timeoutMsg) {
         try {
             String log = FileUtils.readFileToString(new File(logFile), Charset.defaultCharset());


### PR DESCRIPTION
As mentioned in documentation of com.google.common.collect:

Lists::newArrayList()

> ...Note for Java 7 and later: this method is now unnecessary and be treated as deprecated. Instead, use the ArrayList constructor directly...

Lists::newArrayList(E... elements)

> ...This method is not actually very useful and will likely be deprecated in the future...

Maps::newHashMap()

> Note for Java 7 and later: this method is now unnecessary and should be treated as deprecated. Instead, use the HashMap constructor directly
