### PR TITLE
More messaging fixes

### DIFF
--- a/src/main/java/com/sixt/service/framework/kafka/messaging/Metadata.java
+++ b/src/main/java/com/sixt/service/framework/kafka/messaging/Metadata.java
@@ -130,15 +130,26 @@ public class Metadata {
 
     public Marker getLoggingMarker() {
         // If we get more optional header fields, we should probably exclude them if they are empty.
-        Marker messageMarker = append("topic", topic)
-                .and(append("partitionId", partitionId))
-                .and(append("partitioningKey", partitioningKey))
-                .and(append("offset", offset))
-                .and(append("messageId", messageId))
-                .and(append("correlationId", correlationId))
-                .and(append("requestCorrelationId", requestCorrelationId))
-                .and(append("replyTo", replyTo))
-                .and(append("messageType", type));
+        Marker messageMarker =
+                append("messageId", messageId)
+                        .and(append("partitionId", partitionId))
+                        .and(append("partitioningKey", partitioningKey))
+                        .and(append("offset", offset))
+                        .and(append("messageId", messageId))
+                        .and(append("correlationId", correlationId))
+                        .and(append("requestCorrelationId", requestCorrelationId));
+
+
+        // Nota bene: without the toString the marker tries to convert the object into Json, which produces strange results
+        if (topic != null) {
+            messageMarker.add(append("topic", topic.toString()));
+        }
+        if (replyTo != null) {
+            messageMarker.add(append("replyTo", replyTo.toString()));
+        }
+        if (type != null) {
+            messageMarker.add(append("messageType", type.toString()));
+        }
 
         return messageMarker;
     }

--- a/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/messaging/KafkaIntegrationTest.java
@@ -82,8 +82,6 @@ public class KafkaIntegrationTest {
         typeDictionary.putHandler(MessageType.of(SayHelloToCmd.class), new MessageHandler<SayHelloToCmd>() {
             @Override
             public void onMessage(Message<SayHelloToCmd> message, OrangeContext context) {
-                System.err.println(message);
-
                 SayHelloToReply greeting = SayHelloToReply.newBuilder().setGreeting("Hello to " + message.getPayload().getName()).build();
                 Message reply = Messages.replyTo(message, greeting, context);
 
@@ -96,7 +94,6 @@ public class KafkaIntegrationTest {
         typeDictionary.putHandler(MessageType.of(SayHelloToReply.class), new MessageHandler<SayHelloToReply>() {
             @Override
             public void onMessage(Message<SayHelloToReply> message, OrangeContext context) {
-                System.err.println(message);
                 responseLatch.countDown();
             }
         });


### PR DESCRIPTION
Fixed logging marker: use toString or otherwise the logging marker will try to create a (broken) json object out of e.g. the topic.