### PR TITLE
Make KafkaProducer configurable with custom properties

### DIFF
--- a/sit/src/main/java/com/sixt/service/test_service/ServiceEntryPoint.java
+++ b/sit/src/main/java/com/sixt/service/test_service/ServiceEntryPoint.java
@@ -12,18 +12,13 @@
 
 package com.sixt.service.test_service;
 
-import com.google.common.collect.ImmutableSet;
 import com.sixt.service.framework.AbstractService;
 import com.sixt.service.framework.annotation.OrangeMicroservice;
-import com.sixt.service.framework.kafka.TopicVerification;
 import com.sixt.service.framework.kafka.messaging.ConsumerFactory;
 import com.sixt.service.framework.kafka.messaging.DiscardFailedMessages;
-import com.sixt.service.framework.kafka.messaging.Topic;
-import com.sixt.service.framework.util.Sleeper;
 import com.sixt.service.test_service.handler.*;
 
 import java.io.PrintStream;
-import java.util.Set;
 
 @OrangeMicroservice
 public class ServiceEntryPoint extends AbstractService {

--- a/sit/src/main/java/com/sixt/service/test_service/handler/RandomHandler.java
+++ b/sit/src/main/java/com/sixt/service/test_service/handler/RandomHandler.java
@@ -1,23 +1,25 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
 package com.sixt.service.test_service.handler;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.sixt.service.framework.OrangeContext;
 import com.sixt.service.framework.ServiceMethodHandler;
 import com.sixt.service.framework.rpc.RpcCallException;
 import com.sixt.service.test_service.api.TestServiceOuterClass.GetRandomStringQuery;
 import com.sixt.service.test_service.api.TestServiceOuterClass.RandomStringResponse;
+import com.sixt.service.test_service.infrastructure.RandomEventPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +29,12 @@ import java.util.UUID;
 public class RandomHandler implements ServiceMethodHandler<GetRandomStringQuery, RandomStringResponse> {
 
     private static final Logger logger = LoggerFactory.getLogger(RandomHandler.class);
+    private final RandomEventPublisher publisher;
+
+    @Inject
+    public RandomHandler(RandomEventPublisher publisher) {
+        this.publisher = publisher;
+    }
 
     @Override
     public RandomStringResponse handleRequest(GetRandomStringQuery request, OrangeContext ctx) throws RpcCallException {

--- a/sit/src/main/java/com/sixt/service/test_service/infrastructure/RandomEventPublisher.java
+++ b/sit/src/main/java/com/sixt/service/test_service/infrastructure/RandomEventPublisher.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sixt.service.test_service.infrastructure;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.sixt.service.framework.kafka.KafkaPublisher;
+import com.sixt.service.framework.kafka.KafkaPublisherFactory;
+import com.sixt.service.framework.protobuf.ProtobufUtil;
+import com.sixt.service.test_service.api.TestServiceOuterClass;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Singleton
+public class RandomEventPublisher {
+
+    private static final Logger logger = LoggerFactory.getLogger(RandomEventPublisher.class);
+
+    private final KafkaPublisher publisher;
+
+    @Inject
+    public RandomEventPublisher(KafkaPublisherFactory factory) {
+        Map<String, String> props = new HashMap<>();
+        props.put(ProducerConfig.RETRIES_CONFIG, "3");
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        publisher = factory.newBuilder("events", props).build();
+    }
+
+    public void publishSync(TestServiceOuterClass.HandlerSuccessEvent event) {
+        if (!publisher.publishSync(ProtobufUtil.protobufToJson(event).toString())) {
+            logger.warn("Failed to publish event: {}", event);
+        }
+    }
+}

--- a/sit/src/main/proto/TestService.proto
+++ b/sit/src/main/proto/TestService.proto
@@ -32,6 +32,18 @@ message SetHealthCheckStatusResponse {
 }
 
 message RandomSampleEvent {
-    string id = 1;
-    string message = 2;
+    Meta meta = 1;
+    string id = 2;
+    string message = 3;
 }
+
+message HandlerSuccessEvent {
+    Meta meta = 1;
+    string id = 2;
+    string message = 3;
+}
+
+message Meta {
+    string name = 1;
+}
+

--- a/sit/src/serviceTest/java/com/sixt/service/test_service/RandomServiceIntegrationTest.java
+++ b/sit/src/serviceTest/java/com/sixt/service/test_service/RandomServiceIntegrationTest.java
@@ -12,28 +12,21 @@
 
 package com.sixt.service.test_service;
 
-import com.google.gson.JsonObject;
-import com.palantir.docker.compose.DockerComposeRule;
 import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.health.HealthCheck;
 import com.sixt.service.framework.kafka.KafkaPublisher;
 import com.sixt.service.framework.kafka.KafkaPublisherFactory;
 import com.sixt.service.framework.kafka.TopicMessageCounter;
-import com.sixt.service.framework.protobuf.ProtobufUtil;
 import com.sixt.service.framework.rpc.LoadBalancer;
 import com.sixt.service.framework.rpc.RpcCallException;
 import com.sixt.service.framework.rpc.ServiceEndpoint;
-import com.sixt.service.framework.servicetest.helper.DockerComposeHelper;
-import com.sixt.service.framework.servicetest.mockservice.ServiceImpersonator;
-import com.sixt.service.framework.servicetest.service.ServiceUnderTest;
-import com.sixt.service.framework.servicetest.service.ServiceUnderTestImpl;
 import com.sixt.service.test_service.api.TestServiceOuterClass;
 import com.sixt.service.test_service.api.TestServiceOuterClass.GetRandomStringQuery;
 import com.sixt.service.test_service.api.TestServiceOuterClass.RandomStringResponse;
 import com.sixt.service.test_service.api.TestServiceOuterClass.SetHealthCheckStatusCommand;
 import org.eclipse.jetty.client.HttpClient;
-import org.joda.time.Duration;
-import org.junit.*;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.util.List;
@@ -98,20 +91,20 @@ public class RandomServiceIntegrationTest {
         assertThat(messageCount).isEqualTo(3);
     }
 
-    @Ignore // Test fails when run with gradle, but works when run in IntelliJ. Why? Reason:  org.apache.kafka.common.errors.TimeoutException: Failed to update metadata after 60000 ms.
     @Test
-    public void testRandomSampleEventHandler() throws Exception {
-        ServiceIntegrationTestSuite.serviceImpersonator.publishEvent("events", TestServiceOuterClass.RandomSampleEvent.newBuilder()
-                .setId("some-id")
-                .setMessage("The message")
+    public void testKafkaEventHandlerAndPublisher() throws Exception {
+        String message = "The message";
+        String id = "some-id";
+        ServiceIntegrationTestSuite.serviceImpersonator.publishEvent("events.RandomTopic", TestServiceOuterClass.RandomSampleEvent.newBuilder()
+                .setMeta(TestServiceOuterClass.Meta.newBuilder().setName(TestServiceOuterClass.RandomSampleEvent.getDescriptor().getName()))
+                .setId(id)
+                .setMessage(message)
                 .build());
 
-        List<JsonObject> receivedEvents = ServiceIntegrationTestSuite.testService.getAllJsonEvents();
-
-        assertThat(receivedEvents.size()).isEqualTo(1);
-        TestServiceOuterClass.RandomSampleEvent event = ProtobufUtil.jsonToProtobuf(receivedEvents.get(0).toString(),
-                TestServiceOuterClass.RandomSampleEvent.class);
-        assertThat(event.getId()).isEqualTo("some-id");
-        assertThat(event.getMessage()).isEqualTo("The message");
+        List<TestServiceOuterClass.HandlerSuccessEvent> publishedEvents = ServiceIntegrationTestSuite.testService
+                .getEventsOfType(TestServiceOuterClass.HandlerSuccessEvent.class);
+        assertThat(publishedEvents.size()).isEqualTo(1);
+        assertThat(publishedEvents.get(0).getMessage()).isEqualTo(message);
+        assertThat(publishedEvents.get(0).getId()).isEqualTo(id);
     }
 }

--- a/sit/src/serviceTest/resources/docker-compose.yml
+++ b/sit/src/serviceTest/resources/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - "9092"
     environment:
       KAFKA_ADVERTISED_PORT: 9092
-      KAFKA_CREATE_TOPICS: "inbox_test:3:1,inbox-com.sixt.service.test-service:3:1,message-count:3:1,events:3:1" # events must be last for the healthcheck to work
+      KAFKA_CREATE_TOPICS: "inbox_test:3:1,inbox-com.sixt.service.test-service:3:1,message-count:3:1,events.RandomTopic:3:1,events:3:1" # events must be last for the healthcheck to work
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     volumes:

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaPublisher.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaPublisher.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
@@ -16,10 +16,12 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -28,12 +30,16 @@ public class KafkaPublisher {
 
     private static final Logger logger = LoggerFactory.getLogger(KafkaPublisher.class);
 
-    protected String topic;
-    protected KafkaProducer<String, String> realProducer;
+    private final Map<String, String> properties;
+    private final String topic;
+
+    private KafkaProducer<String, String> realProducer;
+
     protected AtomicBoolean isInitialized = new AtomicBoolean(false);
 
-    public KafkaPublisher(String topic) {
+    KafkaPublisher(String topic, Map<String, String> properties) {
         this.topic = topic;
+        this.properties = properties;
     }
 
     public void initialize(String servers) {
@@ -47,6 +53,9 @@ public class KafkaPublisher {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, SixtPartitioner.class.getName());
+
+        properties.forEach(props::put);
+
         realProducer = new KafkaProducer<>(props);
         isInitialized.set(true);
     }
@@ -54,7 +63,7 @@ public class KafkaPublisher {
     /**
      * Synchronously publish one or more messages with a null partition key
      */
-    public boolean publishSync(String ...events) {
+    public boolean publishSync(String... events) {
         if (events != null) {
             return publishEvents(true, null, events);
         } else {
@@ -65,7 +74,7 @@ public class KafkaPublisher {
     /**
      * Synchronously publish one or more messages with the specified partition key
      */
-    public boolean publishSyncWithKey(String key, String ...events) {
+    public boolean publishSyncWithKey(String key, String... events) {
         if (events != null) {
             return publishEvents(true, key, events);
         } else {
@@ -76,7 +85,7 @@ public class KafkaPublisher {
     /**
      * Asynchronously publish one or more messages with a null partition key
      */
-    public void publishAsync(String ...events) {
+    public void publishAsync(String... events) {
         if (events != null) {
             publishEvents(false, null, events);
         }
@@ -85,7 +94,7 @@ public class KafkaPublisher {
     /**
      * Asynchronously publish one or more messages with a null partition key
      */
-    public void publishAsyncWithKey(String key, String ...events) {
+    public void publishAsyncWithKey(String key, String... events) {
         if (events != null) {
             publishEvents(false, key, events);
         }

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaPublisher.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaPublisher.java
@@ -53,6 +53,8 @@ public class KafkaPublisher {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, SixtPartitioner.class.getName());
+        props.put(ProducerConfig.RETRIES_CONFIG, "3");
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
 
         properties.forEach(props::put);
 

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaPublisherBuilder.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaPublisherBuilder.java
@@ -1,29 +1,35 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
 package com.sixt.service.framework.kafka;
 
+import java.util.Map;
+
 public class KafkaPublisherBuilder {
 
-    protected KafkaPublisherFactory parentFactory;
+    private final Map<String, String> properties;
+
+    private KafkaPublisherFactory parentFactory;
+
     protected String topic;
 
-    KafkaPublisherBuilder(KafkaPublisherFactory factory, String topic) {
+    KafkaPublisherBuilder(KafkaPublisherFactory factory, String topic, Map<String, String> properties) {
         this.parentFactory = factory;
         this.topic = topic;
+        this.properties = properties;
     }
 
     public KafkaPublisher build() {
-        KafkaPublisher retval = new KafkaPublisher(topic);
+        KafkaPublisher retval = new KafkaPublisher(topic, properties);
         parentFactory.builtPublisher(retval);
         return retval;
     }

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaPublisherFactory.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaPublisherFactory.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
@@ -17,13 +17,16 @@ import com.google.inject.Singleton;
 import com.sixt.service.framework.ServiceProperties;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 @Singleton
 public class KafkaPublisherFactory {
 
     protected ServiceProperties serviceProperties;
-    protected Collection<KafkaPublisher> kafkaPublishers = new ConcurrentLinkedQueue<>();
+
+    private Collection<KafkaPublisher> kafkaPublishers = new ConcurrentLinkedQueue<>();
 
     @Inject
     public KafkaPublisherFactory(ServiceProperties serviceProperties) {
@@ -39,10 +42,14 @@ public class KafkaPublisherFactory {
     }
 
     public KafkaPublisherBuilder newBuilder(String topic) {
-        return new KafkaPublisherBuilder(this, topic);
+        return new KafkaPublisherBuilder(this, topic, Collections.emptyMap());
     }
 
-    public void builtPublisher(KafkaPublisher publisher) {
+    public KafkaPublisherBuilder newBuilder(String topic, Map<String, String> properties) {
+        return new KafkaPublisherBuilder(this, topic, properties);
+    }
+
+    void builtPublisher(KafkaPublisher publisher) {
         kafkaPublishers.add(publisher);
         publisher.initialize(serviceProperties.getKafkaServer());
     }


### PR DESCRIPTION
This allows users to customize their KafkaProducer config with custom properties.

For example like this:

    @Inject
    public RandomEventPublisher(KafkaPublisherFactory factory) {
        Map<String, String> props = new HashMap<>();
        props.put(ProducerConfig.RETRIES_CONFIG, "3");
        props.put(ProducerConfig.ACKS_CONFIG, "all");
        publisher = factory.newBuilder("events", props).build();
    }

I also added a callback to the send method of the KafkaProducer which logs success and failures:

     Future<RecordMetadata> future = realProducer.send(record, (metadata, ex) -> {
        if (ex == null) {
            logger.debug("Sent message to Kafka: {}", metadata);
        } else {
            logger.warn("Send failed for record {}", record, ex);
        }
     });

