### PR TITLE
Use protobuf-java-util for protobuf parsing (to and from JSON)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies { //achtung: order does matter!
 
     //Protobuf
     compile "com.google.protobuf:protobuf-java:$versions.protobuf"
-    compile 'com.googlecode.protobuf-java-format:protobuf-java-format:1.4'
+    compile "com.google.protobuf:protobuf-java-util:$versions.protobuf"
 
     //http client
     compile 'com.fasterxml.jackson.core:jackson-core:2.8.5'

--- a/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
+++ b/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
@@ -43,7 +43,7 @@ public class ProtobufUtil {
     /**
      * NOTE: this is only using the first element of the JsonArray
      */
-    public static Message jsonToProtobuf(JsonArray request, Class<? extends Message> messageClass) {
+    public static <TYPE extends Message> TYPE jsonToProtobuf(JsonArray request, Class<TYPE> messageClass) {
         return jsonToProtobuf(request.get(0).toString(), messageClass);
     }
 

--- a/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
+++ b/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
@@ -49,6 +49,8 @@ public class ProtobufUtil {
 
     /**
      * Converts a JSON String to a protobuf message
+     * <p>
+     * Note: Ignores unknown fields
      *
      * @param input        the input String to convert
      * @param messageClass the protobuf message class to convert into

--- a/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
+++ b/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
@@ -1,36 +1,27 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
 package com.sixt.service.framework.protobuf;
 
-import com.google.common.base.CaseFormat;
-import com.google.common.io.BaseEncoding;
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Descriptors;
+import com.google.gson.JsonParser;
 import com.google.protobuf.Message;
-import com.googlecode.protobuf.format.JsonFormat;
+import com.google.protobuf.util.JsonFormat;
 import com.sixt.service.framework.rpc.RpcCallException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.util.List;
-import java.util.Map;
 
 @SuppressWarnings({"StatementWithEmptyBody", "unchecked"})
 public class ProtobufUtil {
@@ -56,35 +47,43 @@ public class ProtobufUtil {
         return jsonToProtobuf(request.get(0).toString(), messageClass);
     }
 
-    public static <TYPE extends Message> TYPE jsonToProtobuf(String request, Class<TYPE> messageClass) {
-        if (request == null) {
+    /**
+     * Converts a JSON String to a protobuf message
+     *
+     * @param input        the input String to convert
+     * @param messageClass the protobuf message class to convert into
+     * @return the converted protobuf message
+     */
+    public static <TYPE extends Message> TYPE jsonToProtobuf(String input, Class<TYPE> messageClass) {
+        if (input == null) {
             return null;
-        } else if ("{}".equals(request)) {
+        } else if ("{}".equals(input)) {
             try {
                 TYPE.Builder builder = getBuilder(messageClass);
                 return (TYPE) builder.getDefaultInstanceForType();
             } catch (Exception e) {
                 logger.warn("Error building protobuf object of type {} from json: {}",
-                        messageClass.getName(), request);
+                        messageClass.getName(), input);
             }
         }
 
         try {
             TYPE.Builder builder = getBuilder(messageClass);
-            JsonFormat formatter = new JsonFormat();
-            try {
-                ByteArrayInputStream stream = new ByteArrayInputStream(request.getBytes());
-                formatter.merge(stream, builder);
-            } catch (IOException e) {
-                logger.warn("Error building protobuf object of type {} from json: {}",
-                        messageClass.getName(), request);
-            }
+            JsonFormat.parser().ignoringUnknownFields().merge(input, builder);
             return (TYPE) builder.build();
         } catch (Exception e) {
             throw new RuntimeException("Error deserializing json to protobuf", e);
         }
     }
 
+    /**
+     * Converts a byte array to a protobuf message
+     *
+     * @param data         the byte array to convert
+     * @param messageClass the protobuf message class to convert into
+     * @return the converted protobuf message
+     * @throws RpcCallException if something goes wrong during the deserialization
+     */
     public static <TYPE extends Message> TYPE byteArrayToProtobuf(byte data[], Class<TYPE> messageClass)
             throws RpcCallException {
         try {
@@ -96,6 +95,12 @@ public class ProtobufUtil {
         }
     }
 
+    /**
+     * Creates an empty protobuf message of the specified type
+     *
+     * @param klass the protobuf message type
+     * @return the generated protobuf message
+     */
     public static <TYPE extends Message> TYPE newEmptyMessage(Class<TYPE> klass) {
         try {
             Message.Builder builder = getBuilder(klass);
@@ -105,151 +110,40 @@ public class ProtobufUtil {
         }
     }
 
-    public static JsonObject protobufToJson(Message output) {
+    /**
+     * Converts a protobuf message to a JSON object
+     * <p>
+     * Note: Preserves the field names as defined in the *.proto definition
+     *
+     * @param input the protobuf message to convert
+     * @return the converted JSON object
+     */
+    public static JsonObject protobufToJson(Message input) {
         JsonObject object = new JsonObject();
-        if (output == null) {
+        if (input == null) {
             logger.warn("Protobuf message was null");
         } else {
-            for (Map.Entry<Descriptors.FieldDescriptor, Object> field : output.getAllFields().entrySet()) {
-                String jsonName = field.getKey().getName();
-                if (field.getKey().isRepeated()) {
-                    JsonArray array = new JsonArray();
-                    List<?> items = (List<?>) field.getValue();
-                    for (Object item : items) {
-                        array.add(serializeField(field.getKey(), item));
-                    }
-                    object.add(jsonName, array);
-                } else {
-                    object.add(jsonName, serializeField(field.getKey(), field.getValue()));
-                }
+            try {
+                String jsonString = JsonFormat.printer().preservingProtoFieldNames().print(input);
+                object = new JsonParser().parse(jsonString).getAsJsonObject();
+            } catch (Exception e) {
+                throw new RuntimeException("Error deserializing protobuf to json", e);
             }
         }
         return object;
     }
 
     /**
-     * Converts a JSON object to a protobuf message
+     * Converts a JSON object to a protobuf message.
+     * <p>
+     * Note: Ignores unknown fields
      *
      * @param builder the proto message type builder
      * @param input   the JSON object to convert
+     * @return the converted protobuf message
      */
     public static Message fromJson(Message.Builder builder, JsonObject input) throws Exception {
-        Descriptors.Descriptor descriptor = builder.getDescriptorForType();
-        for (Map.Entry<String, JsonElement> entry : input.entrySet()) {
-            String protoName = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, entry.getKey());
-            Descriptors.FieldDescriptor field = descriptor.findFieldByName(protoName);
-            if (field == null) {
-                throw new Exception("Can't find descriptor for field " + protoName);
-            }
-            if (field.isRepeated()) {
-                if (!entry.getValue().isJsonArray()) {
-                    // fail
-                }
-                JsonArray array = entry.getValue().getAsJsonArray();
-                for (JsonElement item : array) {
-                    builder.addRepeatedField(field, parseField(field, item, builder));
-                }
-            } else {
-                builder.setField(field, parseField(field, entry.getValue(), builder));
-            }
-        }
+        JsonFormat.parser().ignoringUnknownFields().merge(input.toString(), builder);
         return builder.build();
-    }
-
-    private static JsonElement serializeField(Descriptors.FieldDescriptor field, Object value) {
-        switch (field.getType()) {
-            case DOUBLE:
-                return new JsonPrimitive((Double) value);
-            case FLOAT:
-                return new JsonPrimitive((Float) value);
-            case INT64:
-            case UINT64:
-            case FIXED64:
-            case SINT64:
-            case SFIXED64:
-                return new JsonPrimitive((Long) value);
-            case INT32:
-            case UINT32:
-            case FIXED32:
-            case SINT32:
-            case SFIXED32:
-                return new JsonPrimitive((Integer) value);
-            case BOOL:
-                return new JsonPrimitive((Boolean) value);
-            case STRING:
-                return new JsonPrimitive((String) value);
-            case GROUP:
-            case MESSAGE:
-                return protobufToJson((Message) value);
-            case BYTES:
-                return new JsonPrimitive(BaseEncoding.base64().encode(((ByteString) value).toByteArray()));
-            case ENUM:
-                String protoEnumName = ((Descriptors.EnumValueDescriptor) value).getName();
-                return new JsonPrimitive(protoEnumName);
-        }
-        return null;
-    }
-
-    private static Object parseField(Descriptors.FieldDescriptor field, JsonElement value,
-                                     Message.Builder enclosingBuilder) throws Exception {
-        switch (field.getType()) {
-            case DOUBLE:
-                if (!value.isJsonPrimitive()) {
-                    // fail;
-                }
-                return value.getAsDouble();
-            case FLOAT:
-                if (!value.isJsonPrimitive()) {
-                    // fail;
-                }
-                return value.getAsFloat();
-            case INT64:
-            case UINT64:
-            case FIXED64:
-            case SINT64:
-            case SFIXED64:
-                if (!value.isJsonPrimitive()) {
-                    // fail
-                }
-                return value.getAsLong();
-            case INT32:
-            case UINT32:
-            case FIXED32:
-            case SINT32:
-            case SFIXED32:
-                if (!value.isJsonPrimitive()) {
-                    // fail
-                }
-                return value.getAsInt();
-            case BOOL:
-                if (!value.isJsonPrimitive()) {
-                    // fail
-                }
-                return value.getAsBoolean();
-            case STRING:
-                if (!value.isJsonPrimitive()) {
-                    // fail
-                }
-                return value.getAsString();
-            case GROUP:
-            case MESSAGE:
-                if (!value.isJsonObject()) {
-                    // fail
-                }
-                return fromJson(enclosingBuilder.newBuilderForField(field), value.getAsJsonObject());
-            case BYTES:
-                if (!value.isJsonPrimitive()) {
-                    // fail
-                }
-                return ByteString.copyFrom(BaseEncoding.base64().decode(value.getAsString()));
-            case ENUM:
-                if (!value.isJsonPrimitive()) {
-                    // fail
-                }
-                String protoEnumValue = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE,
-                        value.getAsString());
-                return field.getEnumType().findValueByName(protoEnumValue);
-        }
-        return null;
     }
 }

--- a/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
+++ b/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
@@ -146,4 +146,15 @@ public class ProtobufUtilTest {
         assertThat(message.getId()).isEmpty();
     }
 
+    @Test
+    public void jsonToProtobuf_SimpleJsonWithEmptyUnknownField_MessageEmpty() {
+        // given
+        final String json = "{\"fahrzeug\": {}}"; // key 'fahrzeug' does not exist in protobuf message FrameworkTest.SerializationTest.
+
+        // when
+        FrameworkTest.SerializationTest message = ProtobufUtil.jsonToProtobuf(json, FrameworkTest.SerializationTest.class);
+
+        // then
+        assertThat(message.getId()).isEmpty();
+    }
 }

--- a/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
+++ b/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
@@ -42,13 +42,14 @@ public class ProtobufUtilTest {
         assertThat(blahArray).containsOnly("a", "b", "c");
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testNullSubmessage() throws Exception {
+    @Test
+    public void testNullSubmessage_YieldsDefaultInstance() throws Exception {
         FrameworkTest.SerializationTest.Builder builder = FrameworkTest.SerializationTest.newBuilder();
         String jsonInput = "{\"id\":\"a\",\"id2\":\"b\",\"id4\":\"c\",\"sub_message\":null}";
         JsonObject json = (JsonObject) new JsonParser().parse(jsonInput);
-        FrameworkTest.SerializationTest message = (FrameworkTest.SerializationTest)ProtobufUtil.fromJson(builder, json);
-        boolean brk = true;
+        FrameworkTest.SerializationTest message = (FrameworkTest.SerializationTest) ProtobufUtil.fromJson(builder, json);
+
+        assertThat(message.getSubMessage()).isEqualTo(FrameworkTest.SerializationSubMessage.getDefaultInstance());
     }
 
     @Test
@@ -94,8 +95,8 @@ public class ProtobufUtilTest {
         FrameworkTest.SerializationTest message = FrameworkTest.SerializationTest.newBuilder()
                 .setSubMessage(
                         FrameworkTest.SerializationSubMessage.newBuilder()
-                        .setId("TheId")
-                        .build()
+                                .setId("TheId")
+                                .build()
                 ).setId4("The fourth id")
                 .build();
 
@@ -118,7 +119,7 @@ public class ProtobufUtilTest {
 
         // then
         assertThat(message).isInstanceOf(FrameworkTest.SerializationTest.class);
-        assertThat(((FrameworkTest.SerializationTest)message).getId()).isEqualTo("theId");
+        assertThat(((FrameworkTest.SerializationTest) message).getId()).isEqualTo("theId");
     }
 
     @Test
@@ -144,5 +145,5 @@ public class ProtobufUtilTest {
         // then
         assertThat(message.getId()).isEmpty();
     }
-    
+
 }


### PR DESCRIPTION
### Description of the Change

I propose to use http://mvnrepository.com/artifact/com.google.protobuf/protobuf-java-util for parsing protobuf messages to and from JSON instead of a combination of self-written code and http://mvnrepository.com/artifact/com.googlecode.protobuf-java-format/protobuf-java-format.

### Benefits

- Exchanging `protobuf-java-format` (is not being maintained anymore, last release: November 2015) with the actively maintained `protobuf-java-util`
- protobuf-java-util provides standardized serialization and deserialization
- version of protobuf-java-util matches the protobuf version we use in the projects
- using official code published by google instead of our own version

### Possible Drawbacks

None, as far as I know.
