### PR TITLE
Allow converting empty string to protobuf message and mark behaviour …

### DIFF
--- a/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
+++ b/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
@@ -59,7 +59,13 @@ public class ProtobufUtil {
     public static <TYPE extends Message> TYPE jsonToProtobuf(String input, Class<TYPE> messageClass) {
         if (input == null) {
             return null;
-        } else if ("{}".equals(input)) {
+        }
+
+        if ("{}".equals(input) || "".equals(input)) {
+            if ("".equals(input)) {
+                logger.warn("Converting empty String to protobuf message: " +
+                        "This behaviour is deprecated and will be removed in the next major release.");
+            }
             try {
                 TYPE.Builder builder = getBuilder(messageClass);
                 return (TYPE) builder.getDefaultInstanceForType();

--- a/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
+++ b/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
@@ -172,6 +172,18 @@ public class ProtobufUtilTest {
         assertThat(message).isEqualTo(FrameworkTest.SerializationTest.getDefaultInstance());
     }
 
+    @Test // this behaviour is deprecated and will be removed in the next major release
+    public void jsonToProtobuf_InvalidJson_YieldDefaultInstance() throws Exception {
+        // given
+        String json = "invalidJson";
+
+        // when
+        FrameworkTest.SerializationTest message = ProtobufUtil.jsonToProtobuf(json, FrameworkTest.SerializationTest.class);
+
+        // then
+        assertThat(message).isEqualTo(FrameworkTest.SerializationTest.getDefaultInstance());
+    }
+
     @Test
     public void jsonToProtobuf_SimpleJsonToProtobufGeneralMessage_YieldsSuccess() {
         // given

--- a/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
+++ b/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
@@ -160,6 +160,18 @@ public class ProtobufUtilTest {
         assertThat(message).isEqualTo(FrameworkTest.SerializationTest.getDefaultInstance());
     }
 
+    @Test // this behaviour is deprecated and will be removed in the next major release
+    public void jsonToProtobuf_EmptyString_YieldDefaultInstance() throws Exception {
+        // given
+        String json = "";
+
+        // when
+        FrameworkTest.SerializationTest message = ProtobufUtil.jsonToProtobuf(json, FrameworkTest.SerializationTest.class);
+
+        // then
+        assertThat(message).isEqualTo(FrameworkTest.SerializationTest.getDefaultInstance());
+    }
+
     @Test
     public void jsonToProtobuf_SimpleJsonToProtobufGeneralMessage_YieldsSuccess() {
         // given


### PR DESCRIPTION
…as deprecated

### Description of the Change

Before changing the protobuf parsing to use the default google library, ja-micro allowed passing an empty string to the method `ProtobufUtil.jsonToProtobuf` by returning a default instance of the protobuf object.

The last release broke this behavior. Although I believe that the previous behavior was incorrect we should still remain backward compatible and do not make breaking changes.

This PR will allow parsing an empty string to the default instance again and will produce a warning message. The behavior is marked as deprecated and will be removed in a future release.