### PR TITLE
convert protobuf to json with including default field value

### DIFF
--- a/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
+++ b/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
@@ -161,6 +161,33 @@ public class ProtobufUtil {
     }
 
     /**
+     * Converts a protobuf message to a JSON object
+     * <p>
+     * Note: Preserves the field names as defined in the *.proto definition
+     * Note:
+     *
+     * @param input the protobuf message to convert
+     * @return the converted JSON object
+     */
+    public static JsonObject protobufToJsonIncludeDefaultValue(Message input) {
+        JsonObject object = new JsonObject();
+        if (input == null) {
+            logger.warn("Protobuf message was null");
+        } else {
+            try {
+                String jsonString = JsonFormat.printer()
+                    .preservingProtoFieldNames()
+                    .includingDefaultValueFields()
+                    .print(input);
+                object = new JsonParser().parse(jsonString).getAsJsonObject();
+            } catch (Exception e) {
+                throw new RuntimeException("Error deserializing protobuf to json", e);
+            }
+        }
+        return object;
+    }
+
+    /**
      * Converts a JSON object to a protobuf message.
      * <p>
      * Note: Ignores unknown fields

--- a/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
+++ b/src/main/java/com/sixt/service/framework/protobuf/ProtobufUtil.java
@@ -169,7 +169,7 @@ public class ProtobufUtil {
      * @param input the protobuf message to convert
      * @return the converted JSON object
      */
-    public static JsonObject protobufToJsonIncludeDefaultValue(Message input) {
+    public static JsonObject protobufToJsonWithDefaultValues(Message input) {
         JsonObject object = new JsonObject();
         if (input == null) {
             logger.warn("Protobuf message was null");

--- a/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
+++ b/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
@@ -306,4 +306,41 @@ public class ProtobufUtilTest {
         // then
         assertThat(message).isEqualTo(FrameworkTest.SerializationTest.getDefaultInstance());
     }
+
+    @Test
+    public void protobufToJson_with_includingDefaultValueFields() {
+        // given
+        FrameworkTest.SerializationTest message = FrameworkTest.SerializationTest.newBuilder().build();
+
+        // when
+        JsonObject result = ProtobufUtil.protobufToJsonIncludeDefaultValue(message);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.get("id").getAsString()).isEqualTo("");
+        assertThat(result.get("id2").getAsString()).isEqualTo("");
+        assertThat(result.get("id4").getAsString()).isEqualTo("");
+        assertThat(result.get("sub_message")).isNull();
+    }
+
+    @Test
+    public void protobufToJson_with_sub_object() {
+        // given
+        FrameworkTest.SerializationTest message = FrameworkTest.SerializationTest.newBuilder()
+            .setSubMessage(
+                FrameworkTest.SerializationSubMessage.newBuilder().build()
+            )
+            .build();
+
+        // when
+        JsonObject result = ProtobufUtil.protobufToJsonIncludeDefaultValue(message);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.get("id").getAsString()).isEqualTo("");
+        assertThat(result.get("id2").getAsString()).isEqualTo("");
+        assertThat(result.get("id4").getAsString()).isEqualTo("");
+        assertThat(result.get("sub_message")).isNotNull();
+        assertThat(result.getAsJsonObject("sub_message").get("id").getAsString()).isEqualTo("");
+    }
 }

--- a/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
+++ b/src/test/java/com/sixt/service/framework/protobuf/ProtobufUtilTest.java
@@ -313,7 +313,7 @@ public class ProtobufUtilTest {
         FrameworkTest.SerializationTest message = FrameworkTest.SerializationTest.newBuilder().build();
 
         // when
-        JsonObject result = ProtobufUtil.protobufToJsonIncludeDefaultValue(message);
+        JsonObject result = ProtobufUtil.protobufToJsonWithDefaultValues(message);
 
         // then
         assertThat(result).isNotNull();
@@ -333,7 +333,7 @@ public class ProtobufUtilTest {
             .build();
 
         // when
-        JsonObject result = ProtobufUtil.protobufToJsonIncludeDefaultValue(message);
+        JsonObject result = ProtobufUtil.protobufToJsonWithDefaultValues(message);
 
         // then
         assertThat(result).isNotNull();


### PR DESCRIPTION
### Description of the Change
convert protobuf to json making null fields empty(default)
### Alternate Designs
no
### Why Should This Be In Core?
need to have possibility to get jsonObject with default field value from protobuf object
### Benefits
the change provides possibility to check on "hasX" field in generated JsonObject
### Possible Drawbacks
no
### Applicable Issues
when convert protobuf to json and after it get value from json object by field name
