### PR TITLE
Provide possibility to intercept RpcHandlers handle method

### DIFF
--- a/src/main/java/com/sixt/service/framework/util/ReflectionUtil.java
+++ b/src/main/java/com/sixt/service/framework/util/ReflectionUtil.java
@@ -29,10 +29,26 @@ public class ReflectionUtil {
             }
         }
 
-        int count = 0;
         Class<?> clazz = instance.getClass();
         Type[] genericInterfaces = clazz.getGenericInterfaces();
 
+        if (genericInterfaces.length > 0) {
+            return retrieveGenericParameterTypes(genericInterfaces, parameterIndex);
+        } else if (clazz.getSuperclass() != null) {
+            return retrieveGenericParameterTypes(
+                clazz.getSuperclass().getGenericInterfaces(),
+                parameterIndex
+            );
+        } else {
+            return null;
+        }
+    }
+
+    private static Class<?> retrieveGenericParameterTypes(
+        final Type[] genericInterfaces,
+        final Integer parameterIndex
+    ) throws ClassNotFoundException {
+        int count = 0;
         for (Type genericInterface : genericInterfaces) {
             if (genericInterface instanceof ParameterizedType) {
                 Type[] genericTypes = ((ParameterizedType) genericInterface).getActualTypeArguments();

--- a/src/test/java/com/sixt/service/framework/util/ReflectionUtilTest.java
+++ b/src/test/java/com/sixt/service/framework/util/ReflectionUtilTest.java
@@ -21,8 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReflectionUtilTest {
 
-    private ReflectionUtil util = new ReflectionUtil();
-
     @Test
     public void verifyReflection() throws ClassNotFoundException {
         TestServiceMethodHandler handler = new TestServiceMethodHandler();
@@ -33,8 +31,27 @@ public class ReflectionUtilTest {
         assertThat(ReflectionUtil.findSubClassParameterType(handler, 2)).isNull();
     }
 
+    @Test
+    public void verifyReflectionWorksWithAChild() throws ClassNotFoundException {
+        ChildTestServiceMethodHandler handler = new ChildTestServiceMethodHandler();
+        assertThat(ReflectionUtil.findSubClassParameterType(handler, 0)).
+            isEqualTo(RpcEnvelope.Request.class);
+        assertThat(ReflectionUtil.findSubClassParameterType(handler, 1)).
+            isEqualTo(RpcEnvelope.Response.class);
+        assertThat(ReflectionUtil.findSubClassParameterType(handler, 2)).isNull();
+    }
+
     private class TestServiceMethodHandler implements
             ServiceMethodHandler<RpcEnvelope.Request, RpcEnvelope.Response> {
+
+        @Override
+        public RpcEnvelope.Response handleRequest(RpcEnvelope.Request request, OrangeContext ctx) {
+            return null;
+        }
+    }
+
+    private class ChildTestServiceMethodHandler
+        extends TestServiceMethodHandler {
 
         @Override
         public RpcEnvelope.Response handleRequest(RpcEnvelope.Request request, OrangeContext ctx) {

--- a/src/test/java/com/sixt/service/framework/util/TestHandlerInterception.java
+++ b/src/test/java/com/sixt/service/framework/util/TestHandlerInterception.java
@@ -1,0 +1,77 @@
+package com.sixt.service.framework.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sixt.service.framework.OrangeContext;
+import com.sixt.service.framework.ServiceMethodHandler;
+import com.sixt.service.framework.protobuf.RpcEnvelope;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.matcher.Matchers;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Test;
+
+public class TestHandlerInterception {
+
+    private static boolean beforeExecuted;
+    private static boolean afterExecuted;
+    private static boolean methodExecuted;
+
+    @Test
+    public void test_interceptor() throws ClassNotFoundException {
+        Injector injector = Guice.createInjector((Module) binder -> binder.bindInterceptor(
+            Matchers.identicalTo(TestedRpcHandler.class),
+            Matchers.any(),
+            new RpcHandlerMethodInterceptor()
+        ));
+
+        TestedRpcHandler methodHandler
+            = injector.getInstance(TestedRpcHandler.class);
+        methodHandler.handleRequest(RpcEnvelope.Request.newBuilder().build(), new OrangeContext());
+
+        SameGuiceModuleAssertionOnInterceptorInvokation sameGuiceModuleAssertionOnInterceptorInvokation
+            = injector.getInstance(SameGuiceModuleAssertionOnInterceptorInvokation.class);
+        sameGuiceModuleAssertionOnInterceptorInvokation.test_that_intercepted_rpc_handler_still_verified();
+
+        assertThat(ReflectionUtil.findSubClassParameterType(methodHandler, 0)).
+            isEqualTo(RpcEnvelope.Request.class);
+        assertThat(ReflectionUtil.findSubClassParameterType(methodHandler, 1)).
+            isEqualTo(RpcEnvelope.Response.class);
+    }
+
+    public class RpcHandlerMethodInterceptor
+        implements MethodInterceptor {
+
+        @Override
+        public Object invoke(final MethodInvocation invocation) throws Throwable {
+            beforeExecuted = true;
+            Object result = invocation.proceed();
+            afterExecuted = true;
+
+            return result;
+        }
+    }
+
+    static class TestedRpcHandler
+        implements ServiceMethodHandler<RpcEnvelope.Request, RpcEnvelope.Response> {
+
+        @Override
+        public RpcEnvelope.Response handleRequest(RpcEnvelope.Request request, OrangeContext ctx) {
+            methodExecuted = true;
+            return RpcEnvelope.Response.getDefaultInstance();
+        }
+    }
+
+    static class SameGuiceModuleAssertionOnInterceptorInvokation {
+
+        void test_that_intercepted_rpc_handler_still_verified() {
+            assertThat(beforeExecuted).isTrue().as("Interceptor should be invoked before method.");
+            assertThat(methodExecuted).isTrue().as("Intercepted method should be executed.");
+            assertThat(afterExecuted).isTrue().as("Interceptor should be invoked after method.");
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change

  Due to the need to simplify our rpc handler implementation with 
 a concepts of: 
  a) similar exception logging strategy;
  b) business object locking;
  c) processing any thrown exception as RpcCallException according to applied concept 

### Alternate Designs

  Change could be done via massive changes in handler registration, 
 but here i believe is a minimal effort change

### Why Should This Be In Core?

   If one needs to apply conceptual change for a set of typical components quickly 
  he can use AOP approach and reach it with minimal efforts.

### Benefits

 1. Anyone can intercept generalized guice components.
 2. Your code could be cleaner due to AOP usage
 3. Simple solutions for typical problems like logging, 
    lock processing etc. might be applied via interceptors

### Possible Drawbacks

Cant imagine yet.

### Applicable Issues