### PR TITLE
Fix generics in KafkaSubscriberFactory to get rid of unchecked warnings

### DIFF
--- a/sit/src/main/java/com/sixt/service/test_service/handler/RandomEventHandler.java
+++ b/sit/src/main/java/com/sixt/service/test_service/handler/RandomEventHandler.java
@@ -19,27 +19,27 @@ import com.sixt.service.framework.kafka.KafkaSubscriber;
 import com.sixt.service.framework.kafka.KafkaSubscriberFactory;
 import com.sixt.service.framework.kafka.KafkaTopicInfo;
 import com.sixt.service.test_service.api.TestServiceOuterClass;
+import com.sixt.service.test_service.api.TestServiceOuterClass.RandomSampleEvent;
 import com.sixt.service.test_service.infrastructure.RandomEventPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Singleton
-public class RandomEventHandler implements EventReceivedCallback<TestServiceOuterClass.RandomSampleEvent> {
+public class RandomEventHandler implements EventReceivedCallback<RandomSampleEvent> {
 
     private static Logger logger = LoggerFactory.getLogger(RandomEventHandler.class);
 
     private final KafkaSubscriber subscriber;
     private final RandomEventPublisher publisher;
 
-    @SuppressWarnings("unchecked")
     @Inject
-    public RandomEventHandler(KafkaSubscriberFactory factory, RandomEventPublisher publisher) {
+    public RandomEventHandler(KafkaSubscriberFactory<RandomSampleEvent> factory, RandomEventPublisher publisher) {
         this.subscriber = factory.newBuilder("events.RandomTopic", this).build();
         this.publisher = publisher;
     }
 
     @Override
-    public void eventReceived(TestServiceOuterClass.RandomSampleEvent message, KafkaTopicInfo topicInfo) {
+    public void eventReceived(RandomSampleEvent message, KafkaTopicInfo topicInfo) {
         try {
             logger.info("Handling RandomSampleEvent event: {}", message);
             // do some handling

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriberBuilder.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriberBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
@@ -16,7 +16,7 @@ import java.util.UUID;
 
 public class KafkaSubscriberBuilder<TYPE> {
 
-    protected KafkaSubscriberFactory parentFactory;
+    protected KafkaSubscriberFactory<TYPE> parentFactory;
     protected EventReceivedCallback<TYPE> callback;
     protected String topic;
     protected String groupId = UUID.randomUUID().toString();
@@ -28,9 +28,9 @@ public class KafkaSubscriberBuilder<TYPE> {
     protected int pollTime = 1000;
     protected int throttleLimit = 100;
 
-    KafkaSubscriberBuilder(KafkaSubscriberFactory factory, String topic,
-                                  EventReceivedCallback<TYPE> callback) {
-        parentFactory = factory;
+    KafkaSubscriberBuilder(KafkaSubscriberFactory<TYPE> factory, String topic,
+                           EventReceivedCallback<TYPE> callback) {
+        this.parentFactory = factory;
         this.topic = topic;
         this.callback = callback;
     }
@@ -84,7 +84,6 @@ public class KafkaSubscriberBuilder<TYPE> {
         return this;
     }
 
-    @SuppressWarnings(value = "unchecked")
     public KafkaSubscriber<TYPE> build() {
         KafkaSubscriber<TYPE> retval = new KafkaSubscriber<>(callback, topic, groupId,
                 enableAutoCommit, offsetReset, minThreads, maxThreads, idleTimeoutSeconds,

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriberFactory.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriberFactory.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Sixt GmbH & Co. Autovermietung KG
- * Licensed under the Apache License, Version 2.0 (the "License"); you may 
- * not use this file except in compliance with the License. You may obtain a 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
  * copy of the License at http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
- * License for the specific language governing permissions and limitations 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
  * under the License.
  */
 
@@ -38,9 +38,8 @@ public class KafkaSubscriberFactory<TYPE> {
         }
     }
 
-    @SuppressWarnings(value = "unchecked")
     public KafkaSubscriberBuilder newBuilder(String topic, EventReceivedCallback<TYPE> callback) {
-        return new KafkaSubscriberBuilder(this, topic, callback);
+        return new KafkaSubscriberBuilder<>(this, topic, callback);
     }
 
     public void builtSubscriber(KafkaSubscriber<TYPE> subscriber) {

--- a/src/test/java/com/sixt/service/framework/kafka/KafkaSubscriberJsonFactoryTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/KafkaSubscriberJsonFactoryTest.java
@@ -23,7 +23,7 @@ public class KafkaSubscriberJsonFactoryTest implements EventReceivedCallback<Str
     @Test
     public void buildSubscriber() throws Exception {
         ServiceProperties properties = new ServiceProperties();
-        KafkaSubscriberFactory factory = new KafkaSubscriberFactory(properties);
+        KafkaSubscriberFactory<String> factory = new KafkaSubscriberFactory<>(properties);
         subscriber = factory.newBuilder("test", this).build();
     }
 

--- a/src/test/java/com/sixt/service/framework/kafka/KafkaThrottlingTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/KafkaThrottlingTest.java
@@ -61,7 +61,7 @@ public class KafkaThrottlingTest {
         KafkaPublisherFactory publisherFactory = new KafkaPublisherFactory(props);
         KafkaPublisher publisher = publisherFactory.newBuilder(topic).build();
 
-        KafkaSubscriberFactory subscriberFactory = new KafkaSubscriberFactory<String>(props);
+        KafkaSubscriberFactory<String> subscriberFactory = new KafkaSubscriberFactory<>(props);
         EventReceivedCallback<String> callback = (message, topicInfo) -> {
             latch.countDown();
             try {
@@ -70,7 +70,6 @@ public class KafkaThrottlingTest {
                 e.printStackTrace();
             }
         };
-        //noinspection unchecked
         subscriberFactory.newBuilder(topic, callback).withPollTime(50).withAutoCommit(true).build();
 
         for (int i = 0; i < messageCount; i++) {

--- a/src/test/java/com/sixt/service/framework/servicetest/eventing/ServiceTestEventHandlerTest.java
+++ b/src/test/java/com/sixt/service/framework/servicetest/eventing/ServiceTestEventHandlerTest.java
@@ -44,7 +44,7 @@ public class ServiceTestEventHandlerTest {
     public void setUp() throws Exception {
         ServiceProperties properties = new ServiceProperties();
         properties.addProperty("kafkaServer", "localhost:9092");
-        KafkaSubscriberFactory kafkaFactory = new KafkaSubscriberFactory(properties);
+        KafkaSubscriberFactory<String> kafkaFactory = new KafkaSubscriberFactory<>(properties);
         eventHandler = new ServiceTestEventHandler(kafkaFactory);
         eventHandler.initialize("events");
     }


### PR DESCRIPTION
### Description of the Change

Fixed the generics of the KafkaSubscriberFactory to get rid of "unchecked" warnings.
