### PR TITLE
Removed logging of config values

### DIFF
--- a/src/main/java/com/sixt/service/framework/configuration/sixt/SixtConfigurationPlugin.java
+++ b/src/main/java/com/sixt/service/framework/configuration/sixt/SixtConfigurationPlugin.java
@@ -123,7 +123,7 @@ public class SixtConfigurationPlugin implements ConfigurationProvider, Runnable 
     private void processValues(List<ConfigurationOuterClass.ValueResponse> valuesList) {
         Map<String, String> newValues = new HashMap<>(valuesList.size());
         for (ConfigurationOuterClass.ValueResponse cv : valuesList) {
-            logger.debug("Got configuration, entry = {}, value = {}", cv.getName(), cv.getBaseValue());
+            logger.debug("Got configuration, entry = {}", cv.getName());
             newValues.put(cv.getName(), cv.getBaseValue());
         }
         configManager.processValues(newValues);


### PR DESCRIPTION
* Removed logging of config values because it may contain sensitive information. 
* Now, simply logging config entry name without logging its value.
