### PR TITLE
Change method to PUT for Consul health check update according to http…

### DIFF
--- a/src/main/java/com/sixt/service/framework/health/HealthCheckManager.java
+++ b/src/main/java/com/sixt/service/framework/health/HealthCheckManager.java
@@ -20,6 +20,7 @@ import com.sixt.service.framework.metrics.MetricBuilderFactory;
 import com.sixt.service.framework.registry.consul.RegistrationManager;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +110,7 @@ public class HealthCheckManager implements Runnable {
     //TODO: specific to consul; need to refactor
     public void updateHealthStatus(HealthCheck.Status status) throws Exception {
         logger.trace("Updating health of {}", serviceProps.getServiceName());
-        ContentResponse httpResponse = httpClient.newRequest(getHealthCheckUri(status)).send();
+        ContentResponse httpResponse = httpClient.newRequest(getHealthCheckUri(status)).method(HttpMethod.PUT).send();
         if (httpResponse.getStatus() != 200) {
             logger.warn("Received {} trying to update health", httpResponse.getStatus());
         }


### PR DESCRIPTION
### Requirements

### Description of the Change

The code uses new request scheme for health check update in Consul 1.x.x. Consul agent now checks for specific HTTP verbs and enforces them for particular endpoint.

### Alternate Designs

Use Consul 0.x.x without changes

### Why Should This Be In Core?

Using ja-micro with Consul 0.x.x leads to high Consul cluster utilization due to [X-Consul-Index permanent updates](https://github.com/hashicorp/consul/issues/3259) 

### Benefits

Decreasing Consul cluster load and RAFT database replication rate 

### Possible Drawbacks

N/A

### Applicable Issues

Internal issue