### PR TITLE
RpcClient should return an internal-server-error if the target service returned an empty response

### DIFF
--- a/src/main/java/com/sixt/service/framework/rpc/HttpClientWrapper.java
+++ b/src/main/java/com/sixt/service/framework/rpc/HttpClientWrapper.java
@@ -137,7 +137,8 @@ public class HttpClientWrapper {
                 logger.debug(getRemoteMethod(), "Caught exception executing request", ex);
             }
 
-            //content.length must always be > 0, because we have an envelope
+            logger.debug("Response status code = {}", lastStatusCode);
+
             if (responseWasSuccessful(decoder, retval, lastStatusCode)) {
                 if (span != null) {
                     Tags.HTTP_STATUS.set(span, lastStatusCode);

--- a/src/main/java/com/sixt/service/framework/rpc/ProtobufRpcCallExceptionDecoder.java
+++ b/src/main/java/com/sixt/service/framework/rpc/ProtobufRpcCallExceptionDecoder.java
@@ -13,6 +13,7 @@
 package com.sixt.service.framework.rpc;
 
 import com.sixt.service.framework.protobuf.ProtobufRpcResponse;
+import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +27,11 @@ public class ProtobufRpcCallExceptionDecoder implements RpcCallExceptionDecoder 
         try {
             if (response != null) {
                 byte[] data = response.getContent();
+                if (ArrayUtils.isEmpty(data)) {
+                    logger.warn("Unable to decode: empty response received");
+                    return new RpcCallException(RpcCallException.Category.InternalServerError,
+                            "Empty response received");
+                }
                 ProtobufRpcResponse pbResponse = new ProtobufRpcResponse(data);
                 String error = pbResponse.getErrorMessage();
                 if (error != null) {

--- a/src/test/java/com/sixt/service/framework/rpc/ProtobufRpcCallExceptionDecoderTest.java
+++ b/src/test/java/com/sixt/service/framework/rpc/ProtobufRpcCallExceptionDecoderTest.java
@@ -1,0 +1,48 @@
+package com.sixt.service.framework.rpc;
+
+import com.google.common.net.MediaType;
+import junitparams.Parameters;
+import org.assertj.core.api.Assertions;
+import org.eclipse.jetty.client.HttpContentResponse;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.net.MediaType.ANY_TYPE;
+import static com.sixt.service.framework.rpc.RpcCallException.Category.InternalServerError;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class ProtobufRpcCallExceptionDecoderTest {
+
+    private final ProtobufRpcCallExceptionDecoder decoder = new ProtobufRpcCallExceptionDecoder();
+
+    @Test
+    public void decodeException_nullContentPassed_InternalServerErrorShouldBeReturned()
+            throws RpcCallException {
+        byte[] content = null;
+        RpcCallException exception = decoder.decodeException(response(content));
+
+        assertThat(exception.getCategory()).isEqualTo(InternalServerError);
+        assertThat(exception.getMessage()).isEqualTo("Empty response received");
+    }
+
+    @Test
+    public void decodeException_zeroLengthContentPassed_InternalServerErrorShouldBeReturned()
+            throws RpcCallException {
+        byte[] content = new byte[0];
+        RpcCallException exception = decoder.decodeException(response(content));
+
+        assertThat(exception.getCategory()).isEqualTo(InternalServerError);
+        assertThat(exception.getMessage()).isEqualTo("Empty response received");
+    }
+
+    private ContentResponse response(byte[] content) {
+        return new HttpContentResponse(null, content, ANY_TYPE.type(), UTF_8.name());
+    }
+
+}


### PR DESCRIPTION
### Requirements

### Description of the Change

<!--

In case an empty response was returned by the t



-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Why Should This Be In Core?

<!-- Explain why this functionality should be in atom/atom as opposed to a package -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
