### PR TITLE
Support for multiple proto files in System Integration Tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.2.15
+version=3.2.16

--- a/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
+++ b/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
@@ -131,12 +131,9 @@ public class RpcMethodScanner {
         String jars[] = classpath.split(":");
         for (String jar : jars) {
             try {
-                rpcMethodDefinitions = searchJar(jar, serviceName);
+                rpcMethodDefinitions.addAll(searchJar(jar, serviceName));
             } catch (IOException e) {
                 e.printStackTrace();
-            }
-            if (!rpcMethodDefinitions.isEmpty()) {
-                break;
             }
         }
         return rpcMethodDefinitions;
@@ -189,10 +186,6 @@ public class RpcMethodScanner {
                 ZipFile zipFile = new ZipFile(jarFile);
                 try (InputStream in = zipFile.getInputStream(ze)) {
                     defs.addAll(inspectProtoFile(in, serviceName));
-                    if (!defs.isEmpty()) {
-                        zipFile.close();
-                        break;
-                    }
                 }
                 zipFile.close();
             }

--- a/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
+++ b/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
@@ -160,9 +160,6 @@ public class RpcMethodScanner {
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            if (!rpcMethodDefinitions.isEmpty()) {
-                return rpcMethodDefinitions;
-            }
         }
 
         return rpcMethodDefinitions;


### PR DESCRIPTION
RpcMethodScanner (used in SITs) now continues to search for RPC methods even after finding some. This means that splitting a service's proto interface into multiple files is now possible. Previously this had caused SITs to fail as only the first found proto file was detected and registered meaning only a sub-set of the RPC methods were then available for testing.

### Benefits

It is helpful in many cases to segregate a proto interface into several smaller interfaces for better code organisation and to separate out different responsibilities.
