### PR TITLE
RPC method scanning now handles duplicate service method detections b…

### DIFF
--- a/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
+++ b/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
@@ -58,6 +58,10 @@ public class RpcMethodScanner {
         Map<String, ServiceMethod<Message>> serviceMethods = new HashMap<>();
         for (RpcMethodDefinition def : rpcMethodDefinitions) {
             try {
+                if (serviceMethods.containsKey(def.getMethodName())) {
+                    continue;
+                }
+
                 logger.info("Adding endpoint {} for {}", def.getMethodName(), serviceName);
 
                 Class<? extends Message> protobufClass = findProtobufClass(protoClasses, def.getResponseType());


### PR DESCRIPTION
RPC method scanning now handles duplicate service method detections better. It will now skip logging and registering an RPC method if an RPC method with the same name was previously found. Before, this was causing the message "Adding endpoint X" to be logged multiple times.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Checks map of registered handler methods to see if the newly found one is already present.
If so, it is skipped.

### Alternate Designs

### Why Should This Be In Core?

Less noisy logs.

### Benefits

### Possible Drawbacks

### Applicable Issues
