### PR TITLE
solve StackOverflowError on recursive proto objects; in registration …

### DIFF
--- a/src/main/java/com/sixt/service/framework/registry/consul/RegistrationManager.java
+++ b/src/main/java/com/sixt/service/framework/registry/consul/RegistrationManager.java
@@ -349,7 +349,9 @@ public class RegistrationManager implements Runnable {
     protected String getProtobufClassFieldDescriptions(Class<? extends Message> messageClass, Set<Class<? extends Message>> visited)
             throws Exception {
 
-        if (visited.contains(messageClass)) return "";
+        if (visited.contains(messageClass)) {
+            return "";
+        }
         visited.add(messageClass);
 
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/sixt/service/framework/registry/consul/RegistrationManager.java
+++ b/src/main/java/com/sixt/service/framework/registry/consul/RegistrationManager.java
@@ -110,6 +110,9 @@ public class RegistrationManager implements Runnable {
                 sleepDuration = (long) (sleepDuration * 1.5);
             } catch (Exception ex) {
                 logger.warn("Caught exception attempting service registration", ex);
+            } catch (Throwable t) {
+                logger.error("Caught throwable attempting service registration", t);
+                throw t;
             }
         }
     }
@@ -326,13 +329,13 @@ public class RegistrationManager implements Runnable {
                 sb.append("\",\"type\":\"");
                 sb.append(requestClass.getSimpleName());
                 sb.append("\",\"values\":[");
-                sb.append(getProtobufClassFieldDescriptions(requestClass));
+                sb.append(getProtobufClassFieldDescriptions(requestClass, new HashSet<>()));
                 sb.append("]},\"response\":{\"name\":\"");
                 sb.append(responseClass.getSimpleName());
                 sb.append("\",\"type\":\"");
                 sb.append(responseClass.getSimpleName());
                 sb.append("\",\"values\":[");
-                sb.append(getProtobufClassFieldDescriptions(responseClass));
+                sb.append(getProtobufClassFieldDescriptions(responseClass, new HashSet<>()));
                 sb.append("]},\"metadata\":{\"stream\":\"false\"}}");
             } catch (Exception e) {
                 logger.error("Error inspecting handlers", e);
@@ -343,8 +346,12 @@ public class RegistrationManager implements Runnable {
         });
     }
 
-    protected String getProtobufClassFieldDescriptions(Class<? extends Message> messageClass)
+    protected String getProtobufClassFieldDescriptions(Class<? extends Message> messageClass, Set<Class<? extends Message>> visited)
             throws Exception {
+
+        if (visited.contains(messageClass)) return "";
+        visited.add(messageClass);
+
         StringBuilder sb = new StringBuilder();
         Constructor<?> constructor = null;
         try {
@@ -374,7 +381,7 @@ public class RegistrationManager implements Runnable {
                 Descriptors.FieldDescriptor childDescriptor = requestDesc.findFieldByName(fd.getName());
                 Message.Builder subMessageBuilder = builder.newBuilderForField(childDescriptor);
                 Message subMessage = subMessageBuilder.build();
-                sb.append(getProtobufClassFieldDescriptions(subMessage.getClass()));
+                sb.append(getProtobufClassFieldDescriptions(subMessage.getClass(), visited));
                 sb.append("]}");
             } else {
                 sb.append(fd.getType().toString().toLowerCase());

--- a/src/test/java/com/sixt/service/framework/registry/consul/RegistrationManagerTest.java
+++ b/src/test/java/com/sixt/service/framework/registry/consul/RegistrationManagerTest.java
@@ -20,6 +20,7 @@ import com.sixt.service.configuration.api.ConfigurationOuterClass;
 import com.sixt.service.framework.OrangeContext;
 import com.sixt.service.framework.ServiceMethodHandler;
 import com.sixt.service.framework.ServiceProperties;
+import com.sixt.service.framework.kafka.messaging.TreeNode;
 import com.sixt.service.framework.protobuf.FrameworkTest.MessageWithMap;
 import com.sixt.service.framework.protobuf.RpcEnvelope;
 import org.junit.Before;
@@ -104,6 +105,13 @@ public class RegistrationManagerTest {
                 "\"type\":\"string\",\"values\":null},{\"name\":\"instances\",\"type\":" +
                 "\"string\",\"values\":null},{\"name\":\"value\",\"type\":\"string\",\"values" +
                 "\":null},{\"name\":\"isEncrypted\",\"type\":\"bool\",\"values\":null}]}]}");
+    }
+
+    @Test
+    public void verifyCircularNestedEndpoint() throws Exception {
+        String result = manager.getProtobufClassFieldDescriptions(TreeNode.class, new HashSet<>());
+        assertThat(result).isEqualTo("{\"name\":\"name\",\"type\":\"string\",\"values\":null}" +
+                ",{\"name\":\"children\",\"type\":\"TreeNode\",\"values\":[]}");
     }
 
     @Test

--- a/src/test/java/com/sixt/service/framework/registry/consul/RegistrationManagerTest.java
+++ b/src/test/java/com/sixt/service/framework/registry/consul/RegistrationManagerTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.zip.Inflater;
 
@@ -82,7 +83,7 @@ public class RegistrationManagerTest {
 
     @Test
     public void verifyNestedProtobufDescriptor() throws Exception {
-        String result = manager.getProtobufClassFieldDescriptions(ConfigurationOuterClass.FullPath.class);
+        String result = manager.getProtobufClassFieldDescriptions(ConfigurationOuterClass.FullPath.class, new HashSet<>());
         assertThat(result).isEqualTo("{\"name\":\"service\",\"type\":\"string\"," +
                 "\"values\":null},{\"name\":\"name\",\"type\":\"string\",\"values\"" +
                 ":null},{\"name\":\"detail\",\"type\":\"VariantDetail\",\"values\":" +
@@ -95,7 +96,7 @@ public class RegistrationManagerTest {
 
     @Test
     public void verifyNestedEndpoint() throws Exception {
-        String result = manager.getProtobufClassFieldDescriptions(ConfigurationOuterClass.Import.class);
+        String result = manager.getProtobufClassFieldDescriptions(ConfigurationOuterClass.Import.class, new HashSet<>());
         assertThat(result).isEqualTo("{\"name\":\"values\",\"type\":\"ImportItem\"," +
                 "\"values\":[{\"name\":\"name\",\"type\":\"string\",\"values\":null},{" +
                 "\"name\":\"value\",\"type\":\"VariantDetail\",\"values\":[{\"name\":" +

--- a/src/test/proto/MessagingTest.proto
+++ b/src/test/proto/MessagingTest.proto
@@ -23,3 +23,8 @@ message TypeDictionaryTest{
 message TestMessageWithNoHandler {
     string a_meaningless_field = 1;
 }
+
+message TreeNode {
+    string name = 1;
+    repeated TreeNode children = 2;
+}


### PR DESCRIPTION
…thread log throwable and rethrow

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed  at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

We have a tree defined in proto file. The object has reference to itself. That causes StackOverflow. The fix is:
1. Catch throwable, log it, and then throw again. This will make future errors like this easily traceable.
2. Track visited classes and skip known ones.

### Alternate Designs

No other designs were considered.

### Why Should This Be In Core?

Actually, this is a fix, not a new feature.

### Benefits

1. More logs and easier error detection.
2. Work with self referencing objects.

### Possible Drawbacks

No drawbacks.

### Applicable Issues

No issues.
