### PR TITLE
bind a diagnostic correlation-id to the kafka event subscriber threads

### DIFF
--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.time.Clock;
 import java.util.*;
@@ -30,6 +31,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.sixt.service.framework.OrangeContext.CORRELATION_ID;
 import static net.logstash.logback.marker.Markers.append;
 
 public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListener {
@@ -243,6 +245,7 @@ public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListene
 
         @Override
         public void run() {
+            MDC.put(CORRELATION_ID, UUID.randomUUID().toString());
             try {
                 callback.eventReceived(message, topicInfo);
             } catch (Exception ex) {


### PR DESCRIPTION
### Requirements

Log statements from kafka subscriber threads should include a correlation-id

### Description of the Change

Added MDC correlation-id mapping

### Why Should This Be In Core?

So the logs from each event consumer thread could be correlated

### Benefits

Helps troubleshoot issues in event consumers

