### PR TITLE
Fix IllegalArgumentException on concurrent metric registration

### DIFF
--- a/src/main/java/com/sixt/service/framework/metrics/MetricBuilder.java
+++ b/src/main/java/com/sixt/service/framework/metrics/MetricBuilder.java
@@ -14,22 +14,21 @@ package com.sixt.service.framework.metrics;
 
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
-@Singleton
+//DO NOT MAKE @Singleton
 public class MetricBuilder {
 
     private static final Logger logger = LoggerFactory.getLogger(MetricBuilder.class);
 
     private final MetricRegistry registry;
+    private List<MetricTag> tags = new ArrayList<>();
 
-    private List<MetricTag> tags;
     private String baseName;
 
     @Inject
@@ -38,48 +37,48 @@ public class MetricBuilder {
     }
 
     public MetricBuilder withTag(String name, String value) {
-        MetricTag metricTag = new MetricTag(name, value);
-
-        if (tags == null) {
-            tags = Lists.newArrayList(metricTag);
-        } else {
-            tags.add(metricTag);
-        }
+        tags.add(new MetricTag(name, value));
 
         return this;
     }
 
-    public synchronized GoTimer buildTimer() {
-        String name = generateName("timing");
-        GoTimer timer = getExistingTimer(name);
-        if (timer == null) {
-            timer = new GoTimer(name);
+    public GoTimer buildTimer() {
+        synchronized (registry) {
+            String name = generateName("timing");
+            GoTimer timer = getExistingTimer(name);
+            if (timer == null) {
+                timer = new GoTimer(name);
 
-            registry.register(name, timer);
+                registry.register(name, timer);
+            }
+            return timer;
         }
-        return timer;
     }
 
-    public synchronized GoCounter buildCounter() {
-        String name = generateName("counter");
-        GoCounter counter = getExistingCounter(name);
-        if (counter == null) {
-            counter = new GoCounter(name);
+    public GoCounter buildCounter() {
+        synchronized (registry) {
+            String name = generateName("counter");
+            GoCounter counter = getExistingCounter(name);
+            if (counter == null) {
+                counter = new GoCounter(name);
 
-            registry.register(name, counter);
+                registry.register(name, counter);
+            }
+            return counter;
         }
-        return counter;
     }
 
-    public synchronized GoGauge buildGauge() {
-        String name = generateName("gauge");
-        GoGauge gauge = getExistingGauge(name);
-        if (gauge == null) {
-            gauge = new GoGauge(name);
+    public GoGauge buildGauge() {
+        synchronized (registry) {
+            String name = generateName("gauge");
+            GoGauge gauge = getExistingGauge(name);
+            if (gauge == null) {
+                gauge = new GoGauge(name);
 
-            registry.register(name, gauge);
+                registry.register(name, gauge);
+            }
+            return gauge;
         }
-        return gauge;
     }
 
     private GoTimer getExistingTimer(String name) {

--- a/src/main/java/com/sixt/service/framework/metrics/MetricBuilder.java
+++ b/src/main/java/com/sixt/service/framework/metrics/MetricBuilder.java
@@ -27,7 +27,7 @@ public class MetricBuilder {
     private static final Logger logger = LoggerFactory.getLogger(MetricBuilder.class);
 
     private final MetricRegistry registry;
-    private List<MetricTag> tags = new ArrayList<>();
+    private final List<MetricTag> tags = new ArrayList<>();
 
     private String baseName;
 

--- a/src/test/java/com/sixt/service/framework/metrics/MetricBuilderTest.java
+++ b/src/test/java/com/sixt/service/framework/metrics/MetricBuilderTest.java
@@ -1,0 +1,22 @@
+package com.sixt.service.framework.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.Test;
+
+import java.util.stream.IntStream;
+
+public final class MetricBuilderTest {
+
+    @Test
+    public void testShouldVerifyNoDuplicateMetricRegistered() {
+        final MetricRegistry metricRegistry = new MetricRegistry();
+
+        final MetricBuilderFactory metricBuilderFactory = new MetricBuilderFactory(
+                () -> new MetricBuilder(metricRegistry)
+        );
+
+        IntStream.rangeClosed(0, 500)
+                .parallel()
+                .forEach(i -> metricBuilderFactory.newMetric("metric_name").buildCounter().incSuccess());
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR addresses the issue, when multiple threads try to register a the same metric concurrently  in the MetricRegistry (which led to IllegalArgumentException). The MetricBuilder is still created every time upon metric creation, however the synchronization is now performed not on the object itself, but on the MetricRegistry singleton instance.

### Alternate Designs

Its also possible to introduce an additional Lock object to synchronize metric creation, however since MetricRegistry was already available as a singleton anyway, I decided to use it instead. However, if synchronization on that same instance of MetricRegistry in performed elsewhere, it can cause problems. 

### Why Should This Be In Core?

This fixes potential IllegalArgumentException, when multiple threads register the same metric concurrently.

### Benefits

No exception is thrown for concurrent metric registration.

### Possible Drawbacks

Unless synchronization on MetricRegistry is performed somewhere else, no drawbacks are expected.