### PR TITLE
Exit application if environment verification failed

### DIFF
--- a/src/main/java/com/sixt/service/framework/JettyServiceBase.java
+++ b/src/main/java/com/sixt/service/framework/JettyServiceBase.java
@@ -94,18 +94,16 @@ public class JettyServiceBase {
             //we have to start the container before service registration happens to know the port
             service.startJettyContainer();
 
-            Annotation[] serviceAnnos = serviceClass.getAnnotations();
-
             service.initializeServiceRegistration();
 
-            service.verifyEnvironment();
+            verifyEnvironmentAndExistIfNeeded(service);
 
             //we start health checks first so we can see services with bad state
             if (!hcProviders.isEmpty()) {
                 service.initializeHealthCheckManager(hcProviders);
             }
 
-            if (hasAnnotation(serviceAnnos, EnableDatabaseMigration.class)) {
+            if (hasAnnotation(serviceClass.getAnnotations(), EnableDatabaseMigration.class)) {
                 //this will block until the database is available.
                 //it will then attempt a migration.  if the migration fails,
                 //   the process emits an error and pauses.  it's senseless to continue.
@@ -124,6 +122,15 @@ public class JettyServiceBase {
                 service.displayHelp(System.out);
                 System.exit(0);
             }
+        }
+    }
+
+    private static void verifyEnvironmentAndExistIfNeeded(AbstractService service) {
+        try {
+            service.verifyEnvironment();
+        } catch (Exception e) {
+            logger.error("Error while verifying environment - {}", e.getMessage(), e);
+            System.exit(-1);
         }
     }
 


### PR DESCRIPTION
### Description of the Change

This change performs exit from Java process if AbstractService.verifyEnvironment() throws an exception during application start up.

### Benefits

Currently, if method throws an exception, process stays alive, even though application won't function properly. This change makes sure, that if application's environment isn't valid (or something went wrong while trying to verify it), the program will terminate with the proper error logged. (Before, even though the message was logged, application continued to work in a broken state and could potentially confuse monitoring systems)

### Possible Drawbacks

None, unless the semantic of AbstractService.verifyEnvironment() isn't supposed to be treated like that and it's ok to fail and not terminate the application (or if someone has been using it like that already, in which case after this fix application won't start unless no exception is thrown)
