### PR TITLE
add rpc.call span tag (OSRE-1222)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ ext.versions = [
     'guava'    : '23.3-jre',
     'logback'  : '1.2.3',
     'slf4j'    : '1.7.25',
-    'tracing'  : '0.21.0',
+    'tracing'  : '0.31.0',
     'powermock': '1.7.3'
 ]
 

--- a/src/main/java/com/sixt/service/framework/jetty/RpcHandler.java
+++ b/src/main/java/com/sixt/service/framework/jetty/RpcHandler.java
@@ -84,6 +84,7 @@ public abstract class RpcHandler {
                 span = tracer.buildSpan(methodName).start();
             }
             span.setTag("correlation_id", context.getCorrelationId());
+            span.setTag("rpc.call", methodName);
             Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_SERVER);
             Tags.PEER_SERVICE.set(span, context.getRpcOriginService());
             context.setTracingContext(span.context());

--- a/src/main/java/com/sixt/service/framework/rpc/HttpClientWrapper.java
+++ b/src/main/java/com/sixt/service/framework/rpc/HttpClientWrapper.java
@@ -118,6 +118,7 @@ public class HttpClientWrapper {
                     }
                     Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CLIENT);
                     Tags.PEER_SERVICE.set(span, loadBalancer.getServiceName());
+                    span.setTag("rpc.call", client.getServiceMethodName());
                     if (orangeContext != null) {
                         span.setTag("correlation_id", orangeContext.getCorrelationId());
                     }

--- a/src/main/java/com/sixt/service/framework/servicetest/mockservice/ServiceImpersonatorLoadBalancer.java
+++ b/src/main/java/com/sixt/service/framework/servicetest/mockservice/ServiceImpersonatorLoadBalancer.java
@@ -16,7 +16,7 @@ import com.google.inject.Inject;
 import com.sixt.service.framework.ServiceProperties;
 import com.sixt.service.framework.rpc.*;
 import com.sixt.service.framework.servicetest.helper.DockerPortResolver;
-import io.opentracing.NoopTracerFactory;
+import io.opentracing.noop.NoopTracerFactory;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;

--- a/src/main/java/com/sixt/service/framework/tracing/NoopTracingProvider.java
+++ b/src/main/java/com/sixt/service/framework/tracing/NoopTracingProvider.java
@@ -13,8 +13,8 @@
 package com.sixt.service.framework.tracing;
 
 import com.sixt.service.framework.annotation.TracingPlugin;
-import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
+import io.opentracing.noop.NoopTracerFactory;
 
 /**
  * This is the default tracing plugin which just uses the OpenTracing Noop implementation.


### PR DESCRIPTION
To leverage the functionality of Instana 2.0 tracing we need to do the following improvements in our tracing implementations: 

- `peer.service` should be set on the exit spans (this is already done in ja-micro)
- `rpc.call` should be set on both exit and entry spans for rpc calls (this is what this tiny PR is doing)
