### PR TITLE
OSRE-1297: use SASL kafka auth when kafkaPassword is provided

### DIFF
--- a/src/main/java/com/sixt/service/framework/ServiceProperties.java
+++ b/src/main/java/com/sixt/service/framework/ServiceProperties.java
@@ -30,6 +30,7 @@ public class ServiceProperties {
 
     public static final String REGISTRY_SERVER_KEY = "registryServer";
     public static final String KAFKA_SERVER_KEY = "kafkaServer";
+    public static final String KAFKA_PASSWORD_KEY = "kafkaPassword";
     public static final String DATABASE_SERVER_KEY = "databaseServer";
     public static final String DATABASE_USERNAME_KEY = "databaseUsername";
     public static final String DATABASE_PASSWORD_KEY = "databasePassword";
@@ -180,6 +181,10 @@ public class ServiceProperties {
 
     public String getKafkaServer() {
         return allProperties.get(KAFKA_SERVER_KEY);
+    }
+
+    public String getKafkaPassword() {
+        return allProperties.get(KAFKA_PASSWORD_KEY);
     }
 
     public String getDatabaseServer() {

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaPublisher.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaPublisher.java
@@ -48,7 +48,7 @@ public class KafkaPublisher {
         this.metricBuilderFactory = metricBuilderFactory;
     }
 
-    public void initialize(String servers) {
+    public void initialize(String servers, String username, String password) {
         if (isInitialized.get()) {
             logger.warn("Already initialized");
             return;
@@ -56,6 +56,13 @@ public class KafkaPublisher {
 
         Properties props = new Properties();
         props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, servers);
+        if (username != null && !username.isEmpty() && password != null && !password.isEmpty()) {
+            String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule " +
+                "required username=\"%s\" password=\"%s\";";
+            props.put("security.protocol", "SASL_PLAINTEXT");
+            props.put("sasl.mechanism", "PLAIN");
+            props.put("sasl.jaas.config", String.format(jaasTemplate, username, password));
+        }
 
         properties.forEach(props::put);
         buildMetrics();

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaPublisher.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaPublisher.java
@@ -15,6 +15,7 @@ package com.sixt.service.framework.kafka;
 import com.google.common.annotations.VisibleForTesting;
 import com.sixt.service.framework.metrics.GoTimer;
 import com.sixt.service.framework.metrics.MetricBuilderFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -56,7 +57,7 @@ public class KafkaPublisher {
 
         Properties props = new Properties();
         props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, servers);
-        if (username != null && !username.isEmpty() && password != null && !password.isEmpty()) {
+        if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
             String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule " +
                 "required username=\"%s\" password=\"%s\";";
             props.put("security.protocol", "SASL_PLAINTEXT");

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaPublisherFactory.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaPublisherFactory.java
@@ -40,9 +40,11 @@ public class KafkaPublisherFactory {
 
     @Deprecated //no longer needed now that we get populated serviceProperties at guice bootstrap-time
     public void initialize() {
+        String username = serviceProperties.getServiceName();
+        String password = serviceProperties.getKafkaPassword();
         String servers = serviceProperties.getKafkaServer();
         for (KafkaPublisher publisher : kafkaPublishers) {
-            publisher.initialize(servers);
+            publisher.initialize(servers, username, password);
         }
     }
 
@@ -70,7 +72,9 @@ public class KafkaPublisherFactory {
 
     void builtPublisher(KafkaPublisher publisher) {
         kafkaPublishers.add(publisher);
-        publisher.initialize(serviceProperties.getKafkaServer());
+        publisher.initialize(serviceProperties.getKafkaServer(),
+                serviceProperties.getServiceName(),
+                serviceProperties.getKafkaPassword());
     }
 
 }

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
@@ -111,7 +111,7 @@ public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListene
         this.partitionAssignmentWatchdog = partitionAssignmentWatchdog;
     }
 
-    synchronized void initialize(String servers) {
+    synchronized void initialize(String servers, String username, String password) {
         if (isInitialized.get()) {
             logger.warn("Already initialized");
             return;
@@ -128,6 +128,13 @@ public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListene
             props.put("session.timeout.ms", "20000");
             props.put("enable.auto.commit", Boolean.toString(enableAutoCommit));
             props.put("auto.offset.reset", offsetReset.toString().toLowerCase());
+            if (username != null && !username.isEmpty() && password != null && !password.isEmpty()) {
+                String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule " +
+                    "required username=\"%s\" password=\"%s\";";
+                props.put("security.protocol", "SASL_PLAINTEXT");
+                props.put("sasl.mechanism", "PLAIN");
+                props.put("sasl.jaas.config", String.format(jaasTemplate, username, password));
+            }
             realConsumer = new KafkaConsumer<>(props);
 
             List<String> topics = new ArrayList<>();

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
@@ -18,6 +18,7 @@ import com.sixt.service.framework.metrics.GoGauge;
 import com.sixt.service.framework.metrics.MetricBuilderFactory;
 import com.sixt.service.framework.protobuf.ProtobufUtil;
 import com.sixt.service.framework.util.ReflectionUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -128,7 +129,7 @@ public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListene
             props.put("session.timeout.ms", "20000");
             props.put("enable.auto.commit", Boolean.toString(enableAutoCommit));
             props.put("auto.offset.reset", offsetReset.toString().toLowerCase());
-            if (username != null && !username.isEmpty() && password != null && !password.isEmpty()) {
+            if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
                 String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule " +
                     "required username=\"%s\" password=\"%s\";";
                 props.put("security.protocol", "SASL_PLAINTEXT");

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriberFactory.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriberFactory.java
@@ -46,9 +46,11 @@ public class KafkaSubscriberFactory<TYPE> {
 
     @Deprecated //no longer needed now that we get populated serviceProperties at guice bootstrap-time
     public void initialize() {
+        String username = serviceProperties.getServiceName();
+        String password = serviceProperties.getKafkaPassword();
         String servers = serviceProperties.getKafkaServer();
         for (KafkaSubscriber subscriber : kafkaSubscribers) {
-            subscriber.initialize(servers);
+            subscriber.initialize(servers, username, password);
         }
     }
 
@@ -61,7 +63,9 @@ public class KafkaSubscriberFactory<TYPE> {
 
     public void builtSubscriber(KafkaSubscriber<TYPE> subscriber) {
         kafkaSubscribers.add(subscriber);
-        subscriber.initialize(serviceProperties.getKafkaServer());
+        subscriber.initialize(serviceProperties.getKafkaServer(),
+                serviceProperties.getServiceName(),
+                serviceProperties.getKafkaPassword());
     }
 
 }


### PR DESCRIPTION
To provide per-topic ACL we need to implement authentication first. In this PR I enable SASL in the consumer/producer properties if `kafkaPassword` is provided. Otherwise no special auth is used (e.g. PLAIN).