### PR TITLE
use local proto files over jar protos, when file names are matching

### DIFF
--- a/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
+++ b/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
@@ -79,7 +79,7 @@ public class RpcMethodScanner {
     public List<RpcMethodDefinition> getRpcMethodDefinitions(String serviceName) {
         // search classpath
         Map<String, List<RpcMethodDefinition>> jarMap = searchClasspath(serviceName).stream().collect(Collectors.groupingBy(e -> e.getSourceFileName()));
-        // sear local path
+        // search local path
         Map<String, List<RpcMethodDefinition>> localMap = searchDirectory(System.getProperty("user.dir"), serviceName).stream().collect(Collectors.groupingBy(e -> e.getSourceFileName()));
 
         // override jar protos with local protos

--- a/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
+++ b/src/main/java/com/squareup/wire/schema/internal/parser/RpcMethodScanner.java
@@ -77,13 +77,15 @@ public class RpcMethodScanner {
     }
 
     public List<RpcMethodDefinition> getRpcMethodDefinitions(String serviceName) {
-        // first try: search classpath
-        List<RpcMethodDefinition> rpcMethodDefinitions = searchClasspath(serviceName);
+        // search classpath
+        Map<String, List<RpcMethodDefinition>> jarMap = searchClasspath(serviceName).stream().collect(Collectors.groupingBy(e -> e.getSourceFileName()));
+        // sear local path
+        Map<String, List<RpcMethodDefinition>> localMap = searchDirectory(System.getProperty("user.dir"), serviceName).stream().collect(Collectors.groupingBy(e -> e.getSourceFileName()));
 
-        // if rpcMethodDefinitions still empty, : search local directory for proto file
-        if (rpcMethodDefinitions.isEmpty()) {
-            rpcMethodDefinitions = searchDirectory(System.getProperty("user.dir"), serviceName);
-        }
+        // override jar protos with local protos
+        jarMap.putAll(localMap);
+
+        List<RpcMethodDefinition> rpcMethodDefinitions = jarMap.values().stream().flatMap(List::stream).collect(Collectors.toList());
 
         if (rpcMethodDefinitions.isEmpty()) {
             logger.warn("No RPC endpoints found for {}", serviceName);


### PR DESCRIPTION
### Description of the Change

The RPC Scanner was reading jar protos and skip any local file search if jar protos were found. This change will force scan for local protos too will use them over any matching file found in the jars. This allows for working on configuration service, which also has a proto file defined in a dependency jar. Before this fix, any change of configuration service proto was impossible to test locally, because when running the SITs of configuration service, the old proto from the jars will be used.

### Alternate Designs

No alternate designs.

### Why Should This Be In Core?

No new features were added. Just a behavior was slightly tuned.

### Benefits

Gives the possibility to test locally any service that use ja-micro, and also ja-micro depends on (like configuration service).

### Possible Drawbacks

Nothing that we are aware of.

### Applicable Issues

No issues.
