### PR TITLE
implement priority queue per partition for KafkaSubscriber

### DIFF
--- a/src/main/java/com/sixt/service/framework/kafka/EagerMessageQueue.java
+++ b/src/main/java/com/sixt/service/framework/kafka/EagerMessageQueue.java
@@ -4,15 +4,15 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 public class EagerMessageQueue implements MessageQueue {
 
-    private MessageExecuter messageExecuter;
+    private MessageExecutor messageExecutor;
 
-    public EagerMessageQueue(MessageExecuter messageExecuter, long retryDelayMillis) {
-        this.messageExecuter = messageExecuter;
+    public EagerMessageQueue(MessageExecutor messageExecutor, long retryDelayMillis) {
+        this.messageExecutor = messageExecutor;
     }
 
     @Override
     public void add(ConsumerRecord<String, String> record) {
-        messageExecuter.execute(record);
+        messageExecutor.execute(record);
     }
 
     @Override

--- a/src/main/java/com/sixt/service/framework/kafka/EagerMessageQueue.java
+++ b/src/main/java/com/sixt/service/framework/kafka/EagerMessageQueue.java
@@ -1,0 +1,25 @@
+package com.sixt.service.framework.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public class EagerMessageQueue implements MessageQueue {
+
+    private MessageExecuter messageExecuter;
+
+    public EagerMessageQueue(MessageExecuter messageExecuter, long retryDelayMillis) {
+        this.messageExecuter = messageExecuter;
+    }
+
+    @Override
+    public void add(ConsumerRecord<String, String> record) {
+        messageExecuter.execute(record);
+    }
+
+    @Override
+    public void consumed(KafkaTopicInfo topicInfo) {
+    }
+
+    @Override
+    public void processingEnded(KafkaTopicInfo topicInfo) {
+    }
+}

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
@@ -343,4 +343,5 @@ public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListene
         }
     }
 
+
 }

--- a/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
+++ b/src/main/java/com/sixt/service/framework/kafka/KafkaSubscriber.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.sixt.service.framework.OrangeContext.CORRELATION_ID;
 import static net.logstash.logback.marker.Markers.append;
 
-public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListener, MessageExecuter {
+public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListener, MessageExecutor {
 
     private static final Logger logger = LoggerFactory.getLogger(KafkaSubscriber.class);
 
@@ -54,9 +54,9 @@ public class KafkaSubscriber<TYPE> implements Runnable, ConsumerRebalanceListene
             this.messageQueueType = messageQueueType;
         }
 
-        public MessageQueue getMessageQueueInstance(MessageExecuter executor, long retryDelayMillis) {
+        public MessageQueue getMessageQueueInstance(MessageExecutor executor, long retryDelayMillis) {
             try {
-                Constructor<? extends MessageQueue> c = messageQueueType.getConstructor(MessageExecuter.class, long.class);
+                Constructor<? extends MessageQueue> c = messageQueueType.getConstructor(MessageExecutor.class, long.class);
                 return c.newInstance(executor, retryDelayMillis);
             } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
                 throw new RuntimeException("Failed to create message queue instance of type " + name(), e);

--- a/src/main/java/com/sixt/service/framework/kafka/MessageExecuter.java
+++ b/src/main/java/com/sixt/service/framework/kafka/MessageExecuter.java
@@ -1,0 +1,7 @@
+package com.sixt.service.framework.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface MessageExecuter {
+    void execute(ConsumerRecord<String, String> record);
+}

--- a/src/main/java/com/sixt/service/framework/kafka/MessageExecutor.java
+++ b/src/main/java/com/sixt/service/framework/kafka/MessageExecutor.java
@@ -2,6 +2,6 @@ package com.sixt.service.framework.kafka;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-public interface MessageExecuter {
+public interface MessageExecutor {
     void execute(ConsumerRecord<String, String> record);
 }

--- a/src/main/java/com/sixt/service/framework/kafka/MessageQueue.java
+++ b/src/main/java/com/sixt/service/framework/kafka/MessageQueue.java
@@ -1,0 +1,9 @@
+package com.sixt.service.framework.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface MessageQueue {
+    void add(ConsumerRecord<String, String> record);
+    void consumed(KafkaTopicInfo topicInfo);
+    void processingEnded(KafkaTopicInfo topicInfo);
+}

--- a/src/main/java/com/sixt/service/framework/kafka/PriorityMessageQueue.java
+++ b/src/main/java/com/sixt/service/framework/kafka/PriorityMessageQueue.java
@@ -11,14 +11,14 @@ public class PriorityMessageQueue implements MessageQueue {
 
     private Map<Integer, TreeSet<ConsumerRecord<String, String>>> partitionQueue;
     private Map<Integer, ConsumerRecord<String, String>> inProgress;
-    private MessageExecuter messageExecuter;
+    private MessageExecutor messageExecutor;
     private ScheduledExecutorService retryExecutor;
     private long retryDelayMillis;
 
-    public PriorityMessageQueue(MessageExecuter messageExecuter, long retryDelayMillis) {
+    public PriorityMessageQueue(MessageExecutor messageExecutor, long retryDelayMillis) {
         this.partitionQueue = new HashMap<>();
         this.inProgress = new HashMap<>();
-        this.messageExecuter = messageExecuter;
+        this.messageExecutor = messageExecutor;
         this.retryExecutor = Executors.newSingleThreadScheduledExecutor();
         this.retryDelayMillis = retryDelayMillis;
     }
@@ -49,7 +49,7 @@ public class PriorityMessageQueue implements MessageQueue {
         final ConsumerRecord<String, String> record = inProgress.get(topicInfo.getPartition());
         if (record != null && record.offset() == topicInfo.getOffset()) {
             //Processing failed. Schedule retry.
-            retryExecutor.schedule(() -> messageExecuter.execute(record), retryDelayMillis, TimeUnit.MILLISECONDS);
+            retryExecutor.schedule(() -> messageExecutor.execute(record), retryDelayMillis, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -57,7 +57,7 @@ public class PriorityMessageQueue implements MessageQueue {
         TreeSet<ConsumerRecord<String, String>> pQueue = partitionQueue.get(partition);
         if (pQueue != null && !pQueue.isEmpty()) {
             ConsumerRecord<String, String> record = pQueue.first();
-            messageExecuter.execute(record);
+            messageExecutor.execute(record);
             inProgress.put(partition, record);
             pQueue.pollFirst();
         }

--- a/src/main/java/com/sixt/service/framework/kafka/PriorityMessageQueue.java
+++ b/src/main/java/com/sixt/service/framework/kafka/PriorityMessageQueue.java
@@ -1,0 +1,66 @@
+package com.sixt.service.framework.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class PriorityMessageQueue implements MessageQueue {
+
+    private Map<Integer, TreeSet<ConsumerRecord<String, String>>> partitionQueue;
+    private Map<Integer, ConsumerRecord<String, String>> inProgress;
+    private MessageExecuter messageExecuter;
+    private ScheduledExecutorService retryExecutor;
+    private long retryDelayMillis;
+
+    public PriorityMessageQueue(MessageExecuter messageExecuter, long retryDelayMillis) {
+        this.partitionQueue = new HashMap<>();
+        this.inProgress = new HashMap<>();
+        this.messageExecuter = messageExecuter;
+        this.retryExecutor = Executors.newSingleThreadScheduledExecutor();
+        this.retryDelayMillis = retryDelayMillis;
+    }
+
+    @Override
+    public synchronized void add(ConsumerRecord<String, String> record) {
+        int partition = record.partition();
+        TreeSet<ConsumerRecord<String, String>> pQueue = partitionQueue.get(partition);
+        if (pQueue == null) {
+            pQueue = new TreeSet<>(Comparator.comparingLong(ConsumerRecord::offset));
+            partitionQueue.put(partition, pQueue);
+        }
+        pQueue.add(record);
+
+        if (!inProgress.containsKey(partition)) {
+            processNext(partition);
+        }
+    }
+
+    @Override
+    public synchronized void consumed(KafkaTopicInfo topicInfo) {
+        inProgress.remove(topicInfo.getPartition());
+        processNext(topicInfo.getPartition());
+    }
+
+    @Override
+    public synchronized void processingEnded(KafkaTopicInfo topicInfo) {
+        final ConsumerRecord<String, String> record = inProgress.get(topicInfo.getPartition());
+        if (record != null && record.offset() == topicInfo.getOffset()) {
+            //Processing failed. Schedule retry.
+            retryExecutor.schedule(() -> messageExecuter.execute(record), retryDelayMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void processNext(int partition) {
+        TreeSet<ConsumerRecord<String, String>> pQueue = partitionQueue.get(partition);
+        if (pQueue != null && !pQueue.isEmpty()) {
+            ConsumerRecord<String, String> record = pQueue.first();
+            messageExecuter.execute(record);
+            inProgress.put(partition, record);
+            pQueue.pollFirst();
+        }
+
+    }
+}

--- a/src/test/java/com/sixt/service/framework/kafka/EagerMessageQueueTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/EagerMessageQueueTest.java
@@ -1,0 +1,40 @@
+package com.sixt.service.framework.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class EagerMessageQueueTest {
+
+    private MessageExecutor messageExecutor;
+    private MessageQueue messageQueue;
+    private String topic = "topic";
+    private String defaultKey = "key";
+    private String defaultValue = "value";
+
+    @Before
+    public void setup() {
+        messageExecutor = mock(MessageExecutor.class);
+        messageQueue = new EagerMessageQueue(messageExecutor, 5000);
+    }
+
+    @Test
+    public void queue_addTwoRecord_allExecuted() {
+        ConsumerRecord record1 = new ConsumerRecord<>(topic, 0, 0, defaultKey, defaultValue);
+        messageQueue.add(record1);
+        ConsumerRecord record2 = new ConsumerRecord<>(topic, 0, 0, defaultKey, defaultValue);
+        messageQueue.add(record2);
+
+        ArgumentCaptor<ConsumerRecord> captor = ArgumentCaptor.forClass(ConsumerRecord.class);
+        verify(messageExecutor, times(2)).execute(captor.capture());
+        assertThat(captor.getAllValues().get(0)).isEqualTo(record1);
+        assertThat(captor.getAllValues().get(0)).isEqualTo(record2);
+    }
+
+}

--- a/src/test/java/com/sixt/service/framework/kafka/KafkaSubscriberTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/KafkaSubscriberTest.java
@@ -33,7 +33,7 @@ public class KafkaSubscriberTest {
         KafkaSubscriber<String> subscriber = new KafkaSubscriber<>(new MessageCallback(),
                 "topic", "groupId", false,
                 KafkaSubscriber.OffsetReset.Earliest, 1, 1, 1,
-                5000, 5000);
+                5000, 5000, KafkaSubscriber.QueueType.Priority, 1000);
         KafkaTopicInfo message1 = new KafkaTopicInfo("topic", 0, 1, null);
         KafkaTopicInfo message2 = new KafkaTopicInfo("topic", 0, 2, null);
         KafkaTopicInfo message3 = new KafkaTopicInfo("topic", 1, 1, null);

--- a/src/test/java/com/sixt/service/framework/kafka/PriorityMessageQueueTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/PriorityMessageQueueTest.java
@@ -1,0 +1,106 @@
+package com.sixt.service.framework.kafka;
+
+import com.sixt.service.framework.util.Sleeper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class PriorityMessageQueueTest {
+
+    private MessageExecutor messageExecutor;
+    private MessageQueue messageQueue;
+    private String topic = "topic";
+    private String defaultKey = "key";
+    private String defaultValue = "value";
+
+    @Before
+    public void setup() {
+        messageExecutor = mock(MessageExecutor.class);
+        messageQueue = new PriorityMessageQueue(messageExecutor, 5000);
+    }
+
+    @Test
+    public void queue_addRecord_execeuted() {
+        ConsumerRecord record = new ConsumerRecord<>(topic, 0, 0, defaultKey, defaultValue);
+        messageQueue.add(record);
+
+        ArgumentCaptor<ConsumerRecord> captor = ArgumentCaptor.forClass(ConsumerRecord.class);
+        verify(messageExecutor).execute(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(record);
+    }
+
+    @Test
+    public void queue_addRecordsInOnePartition_firstExecuted() {
+        ConsumerRecord record1 = new ConsumerRecord<>(topic, 0, 0, defaultKey, defaultValue);
+        messageQueue.add(record1);
+        messageQueue.add(new ConsumerRecord<>(topic, 0, 1, defaultKey, defaultValue));
+
+        ArgumentCaptor<ConsumerRecord> captor = ArgumentCaptor.forClass(ConsumerRecord.class);
+        verify(messageExecutor).execute(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(record1);
+    }
+
+    @Test
+    public void queue_addRecordsInTwoPartition_bothExecuted() {
+        ConsumerRecord record1 = new ConsumerRecord<>(topic, 0, 0, defaultKey, defaultValue);
+        messageQueue.add(record1);
+        messageQueue.add(new ConsumerRecord<>(topic, 0, 1, defaultKey, defaultValue));
+        messageQueue.add(new ConsumerRecord<>(topic, 0, 2, defaultKey, defaultValue));
+        ConsumerRecord record2 = new ConsumerRecord<>(topic, 1, 1, defaultKey, defaultValue);
+        messageQueue.add(record2);
+        messageQueue.add(new ConsumerRecord<>(topic, 1, 1, defaultKey, defaultValue));
+        messageQueue.add(new ConsumerRecord<>(topic, 1, 2, defaultKey, defaultValue));
+
+        ArgumentCaptor<ConsumerRecord> captor = ArgumentCaptor.forClass(ConsumerRecord.class);
+        verify(messageExecutor, times(2)).execute(captor.capture());
+        assertThat(captor.getAllValues().get(0)).isEqualTo(record1);
+        assertThat(captor.getAllValues().get(1)).isEqualTo(record2);
+    }
+
+    @Test
+    public void queue_consumeRecord_nextExecuted() {
+        ConsumerRecord record1 = new ConsumerRecord<>(topic, 0, 0, defaultKey, defaultValue);
+        messageQueue.add(record1);
+        ConsumerRecord record2 = new ConsumerRecord<>(topic, 0, 1, defaultKey, defaultValue);
+        messageQueue.add(record2);
+        ConsumerRecord record3 = new ConsumerRecord<>(topic, 0, 2, defaultKey, defaultValue);
+        messageQueue.add(record3);
+
+        messageQueue.consumed(new KafkaTopicInfo(topic, 0, 0, defaultKey));
+        messageQueue.consumed(new KafkaTopicInfo(topic, 0, 1, defaultKey));
+        messageQueue.consumed(new KafkaTopicInfo(topic, 0, 2, defaultKey));
+
+        ArgumentCaptor<ConsumerRecord> captor = ArgumentCaptor.forClass(ConsumerRecord.class);
+        verify(messageExecutor, times(3)).execute(captor.capture());
+        assertThat(captor.getAllValues().get(0)).isEqualTo(record1);
+        assertThat(captor.getAllValues().get(1)).isEqualTo(record2);
+        assertThat(captor.getAllValues().get(2)).isEqualTo(record3);
+    }
+
+    @Test
+    public void queue_processingEnded_retryScheduled() {
+        messageQueue = new PriorityMessageQueue(messageExecutor, 100);
+        ConsumerRecord record1 = new ConsumerRecord<>(topic, 0, 0, defaultKey, defaultValue);
+        messageQueue.add(record1);
+        messageQueue.add(new ConsumerRecord<>(topic, 0, 1, defaultKey, defaultValue));
+        messageQueue.add(new ConsumerRecord<>(topic, 0, 2, defaultKey, defaultValue));
+
+        messageQueue.processingEnded(new KafkaTopicInfo(topic, 0, 0, defaultKey));
+        new Sleeper().sleepNoException(120);
+        messageQueue.processingEnded(new KafkaTopicInfo(topic, 0, 0, defaultKey));
+        new Sleeper().sleepNoException(120);
+
+        ArgumentCaptor<ConsumerRecord> captor = ArgumentCaptor.forClass(ConsumerRecord.class);
+        verify(messageExecutor, times(3)).execute(captor.capture());
+        assertThat(captor.getAllValues().get(0)).isEqualTo(record1);
+        assertThat(captor.getAllValues().get(1)).isEqualTo(record1);
+        assertThat(captor.getAllValues().get(2)).isEqualTo(record1);
+    }
+
+}

--- a/src/test/java/com/sixt/service/framework/kafka/PriorityMessageQueueTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/PriorityMessageQueueTest.java
@@ -26,7 +26,7 @@ public class PriorityMessageQueueTest {
     }
 
     @Test
-    public void queue_addRecord_execeuted() {
+    public void queue_addRecord_executed() {
         ConsumerRecord record = new ConsumerRecord<>(topic, 0, 0, defaultKey, defaultValue);
         messageQueue.add(record);
 

--- a/src/test/java/com/sixt/service/framework/kafka/QueueTypeEnumTest.java
+++ b/src/test/java/com/sixt/service/framework/kafka/QueueTypeEnumTest.java
@@ -1,0 +1,17 @@
+package com.sixt.service.framework.kafka;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class QueueTypeEnumTest {
+
+    @Test
+    public void getMessageQueueInstance_succes() {
+        assertThat(KafkaSubscriber.QueueType.Priority.getMessageQueueInstance(mock(MessageExecutor.class), 100))
+                .isInstanceOf(PriorityMessageQueue.class);
+        assertThat(KafkaSubscriber.QueueType.Eager.getMessageQueueInstance(mock(MessageExecutor.class), 100))
+                .isInstanceOf(EagerMessageQueue.class);
+    }
+}


### PR DESCRIPTION
### Description of the Change

KafkaSubscriber was reading all available events and pushing them to a single thread executor. This approach happened to be error prone, and more specifically, if a message handling fails, and then the next message of the same kafka partition turns to be handled successfully, the new offset will be committed to kafka and this will prevent ja-micro from offering the failed message for retry. In this way a temporary dependency unavailability of a message handler may turn into persistent data loss on the consumer side.

To improve this behavior we introduce a priority message queue in KafkaSubscriber. PriorityMessageQueue will block handling of following event per partition, until notified for successful handling. If message processing fails, a retry will be scheduled after certain amount of time. Processing of messages from the same topic will continue for all other partitions in the same way.

### Alternate Designs

No alternatives.

### Why Should This Be In Core?

It is part of the KafkaSubscriber which is already in core.

### Benefits

Guarantees that no events will be skipped due to eager offset commits.

### Possible Drawbacks

No drawbacks. Old approach is still available as EagerMessageQueue. A dev can use it but setting queueType in kafkaSubscriberBuilder to Eager.

### Applicable Issues

No issues.
