### PR TITLE
Add source jar publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.gradle/
 /.idea/
+*.iml
 /classes/
 **/build/
 /out/

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,15 @@ def pomConfig = {
     }
 }
 
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives sourcesJar
+}
+
 publishing {
     publications {
         MyPublication(MavenPublication) {


### PR DESCRIPTION
### Description of the Change

Add source jar publishing. 

### Benefits

It can be requested of jfrog bintray to index the artifact and serve it from their maven repo.

